### PR TITLE
Fix tests and templates; add docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.pytest_cache/
+*.pyc
+family_planner.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# Family-planner
-Family-planner
+# Family Planner
+
+A simple planner application with a Flask API and command line interface for managing users, children, events and shifts.
+
+## Setup
+
+Install the required packages using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+The application uses SQLite by default. Running the app will create a local database file if it does not exist.
+
+## Usage
+
+### Command Line
+Run the CLI to manage data from the terminal:
+
+```bash
+python main.py
+```
+
+### Flask Web App
+Start the web interface:
+
+```bash
+python app.py
+```
+
+Visit `http://localhost:5000` in your browser.
+
+## Running Tests
+
+Install the requirements as above and run:
+
+```bash
+pytest
+```
+
+This will execute the unit tests for the API and manager modules.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+SQLAlchemy
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 {% block content %}
     <h2>Welcome to the Family Planner!</h2>
     <p>This application helps you manage your family's schedule, shifts, and events.</p>
-    {% if session['user_id'] %}
+    {% if session.get('user_id') %}
         <p>You are logged in. You can now manage your data or <a href="{{ url_for('logout') }}">logout</a>.</p>
     {% else %}
         <p>Please <a href="{{ url_for('login') }}">login</a> or <a href="{{ url_for('register') }}">register</a> to continue.</p>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -30,7 +30,7 @@
         <nav>
             <ul>
                 <li><a href="{{ url_for('index') }}">Home</a></li>
-                {% if session['user_id'] %}
+                {% if session.get('user_id') %}
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
                     {# Add other authenticated links here, e.g., Profile, Dashboard #}
                 {% else %}

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import os
 import hashlib
+import sys
 
 # Adjust the path to include the root directory of the project
 # This is crucial for the test runner to find the 'app' module and 'src'

--- a/tests/test_api_children_residency.py
+++ b/tests/test_api_children_residency.py
@@ -3,6 +3,7 @@ import json
 import os
 import hashlib
 from datetime import datetime, date, timedelta
+import sys
 
 # Adjust path
 sys_path_updated = False

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -3,6 +3,7 @@ import json
 import os
 import hashlib
 from datetime import datetime, date
+import sys
 
 # Adjust path
 sys_path_updated = False

--- a/tests/test_api_shifts.py
+++ b/tests/test_api_shifts.py
@@ -3,6 +3,7 @@ import json
 import os
 import hashlib # For direct user creation if needed, though auth API is preferred
 from datetime import datetime, timedelta
+import sys
 
 # Adjust path
 sys_path_updated = False


### PR DESCRIPTION
## Summary
- add missing `sys` imports in API tests
- avoid KeyError by using `session.get` in templates
- document setup and usage instructions
- add gitignore and requirements list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840d4de72bc832a93a30cd077912b11