### PR TITLE
Fix session KeyError in templates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
 {% block content %}
     <h2>Welcome to the Family Planner!</h2>
     <p>This application helps you manage your family's schedule, shifts, and events.</p>
-    {% if session['user_id'] %}
+    {% if session.get('user_id') %}
         <p>You are logged in. You can now manage your data or <a href="{{ url_for('logout') }}">logout</a>.</p>
     {% else %}
         <p>Please <a href="{{ url_for('login') }}">login</a> or <a href="{{ url_for('register') }}">register</a> to continue.</p>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -30,7 +30,7 @@
         <nav>
             <ul>
                 <li><a href="{{ url_for('index') }}">Home</a></li>
-                {% if session['user_id'] %}
+                {% if session.get('user_id') %}
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
                     {# Add other authenticated links here, e.g., Profile, Dashboard #}
                 {% else %}


### PR DESCRIPTION
## Summary
- avoid KeyError when no user is logged in by using `session.get('user_id')`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840d66161d4832ab301ac3784bd8462