### PR TITLE
Fix missing sys import in API test modules

### DIFF
--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import os
 import hashlib
+import sys
 
 # Adjust the path to include the root directory of the project
 # This is crucial for the test runner to find the 'app' module and 'src'

--- a/tests/test_api_children_residency.py
+++ b/tests/test_api_children_residency.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import os
 import hashlib
+import sys
 from datetime import datetime, date, timedelta
 
 # Adjust path

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import os
 import hashlib
+import sys
 from datetime import datetime, date
 
 # Adjust path

--- a/tests/test_api_shifts.py
+++ b/tests/test_api_shifts.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import os
 import hashlib # For direct user creation if needed, though auth API is preferred
+import sys
 from datetime import datetime, timedelta
 
 # Adjust path


### PR DESCRIPTION
## Summary
- add `import sys` to several API test modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6840d65b5fb4832aa0a3c45ffe8a2218