### PR TITLE
Add gitignore for temporary artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.pytest_cache/
+*.pyc
+family_planner.db


### PR DESCRIPTION
## Summary
- add a project `.gitignore` to ignore Python cache directories, compiled files and sqlite db

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `sqlalchemy`)*

------
https://chatgpt.com/codex/tasks/task_e_6840d6654624832a8169b4f277783dbe