### PR TITLE
Improve README with usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # Family-planner
-Family-planner
+
+Een eenvoudige planner voor ouders om diensten, evenementen en verblijfsperiodes van kinderen te beheren.
+
+## Installatie
+
+1. Zorg dat Python 3 geïnstalleerd is.
+2. Installeer de vereisten uit [`requirements.txt`](requirements.txt):
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## CLI gebruiken
+
+Start de commandoregelinterface met:
+```bash
+python main.py
+```
+
+## Flask-app gebruiken
+
+De webapplicatie start je met:
+```bash
+python app.py
+```
+Deze draait standaard op `http://localhost:5000`.
+
+## Tests uitvoeren
+
+Alle unittests kun je draaien met:
+```bash
+python -m unittest discover
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+SQLAlchemy


### PR DESCRIPTION
## Summary
- expand `README` with install, usage and test instructions
- add missing `requirements.txt`

## Testing
- `python -m unittest discover -v tests` *(fails: ModuleNotFoundError for SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6840d66cdc2c832aade8f1ae3dc31f5f