### PR TITLE
Add React Native mobile app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 .pytest_cache/
 *.pyc
 family_planner.db
+mobile_app/node_modules/
+mobile_app/.expo/

--- a/README.md
+++ b/README.md
@@ -39,3 +39,25 @@ pytest
 ```
 
 This will execute the unit tests for the API and manager modules.
+
+## Mobile App
+
+The `mobile_app/` directory contains a minimal React Native project built with Expo.
+
+### Setup
+
+Install Node.js (v18+) and run the following commands inside `mobile_app`:
+
+```bash
+npm install
+```
+
+### Running
+
+Start the Expo development server:
+
+```bash
+npx expo start
+```
+
+Use the Expo app or an emulator to view the login and calendar screens. The app expects the Flask API to be running locally at `http://localhost:5000`.

--- a/mobile_app/App.js
+++ b/mobile_app/App.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from './screens/LoginScreen';
+import CalendarScreen from './screens/CalendarScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Login">
+        <Stack.Screen name="Login" component={LoginScreen} />
+        <Stack.Screen name="Calendar" component={CalendarScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/mobile_app/api/client.js
+++ b/mobile_app/api/client.js
@@ -1,0 +1,23 @@
+const BASE_URL = 'http://localhost:5000';
+
+async function request(path, options = {}) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) },
+    ...options,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.message || 'Request failed');
+  }
+  return res.json();
+}
+
+export default {
+  login: (email, password) =>
+    request('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, password }),
+    }),
+
+  getUserEvents: (userId) => request(`/users/${userId}/events`),
+};

--- a/mobile_app/package.json
+++ b/mobile_app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "family-planner-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "App.js",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-native": "^0.73.0",
+    "expo": "^50.0.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12"
+  }
+}

--- a/mobile_app/screens/CalendarScreen.js
+++ b/mobile_app/screens/CalendarScreen.js
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, StyleSheet } from 'react-native';
+import apiClient from '../api/client';
+
+export default function CalendarScreen({ route }) {
+  const { userId } = route.params;
+  const [events, setEvents] = useState([]);
+
+  useEffect(() => {
+    apiClient
+      .getUserEvents(userId)
+      .then(setEvents)
+      .catch(() => setEvents([]));
+  }, [userId]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Events</Text>
+      <FlatList
+        data={events}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => (
+          <View style={styles.item}>
+            <Text style={styles.itemTitle}>{item.title}</Text>
+            <Text>{item.start_time}</Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+  item: {
+    padding: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: '#ccc',
+  },
+  itemTitle: {
+    fontWeight: 'bold',
+  },
+});

--- a/mobile_app/screens/LoginScreen.js
+++ b/mobile_app/screens/LoginScreen.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import apiClient from '../api/client';
+
+export default function LoginScreen({ navigation }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  const handleLogin = async () => {
+    try {
+      const data = await apiClient.login(email, password);
+      setError(null);
+      navigation.navigate('Calendar', { userId: data.user_id });
+    } catch (e) {
+      setError(e.message || 'Login failed');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Login</Text>
+      {error && <Text style={styles.error}>{error}</Text>}
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        value={email}
+        onChangeText={setEmail}
+        autoCapitalize="none"
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        value={password}
+        onChangeText={setPassword}
+        secureTextEntry
+      />
+      <Button title="Login" onPress={handleLogin} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    marginBottom: 16,
+  },
+  input: {
+    width: '100%',
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 8,
+    marginBottom: 12,
+    borderRadius: 4,
+  },
+  error: {
+    color: 'red',
+    marginBottom: 8,
+  },
+});


### PR DESCRIPTION
## Summary
- create React Native directory `mobile_app` with login and calendar screens
- include an API client for calling the Flask backend
- ignore React Native build artifacts in `.gitignore`
- document mobile app setup and run instructions in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask/sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6840ddeebc74832a9633a310649708bd