### PR TITLE
Add Google Calendar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ pytest
 ```
 
 This will execute the unit tests for the API and manager modules.
+
+## Google Calendar Sync
+
+To enable Google Calendar integration you need API credentials from the
+[Google Cloud Console](https://console.cloud.google.com/). Create an OAuth
+"Web application" or "Desktop" client and download the `credentials.json` file.
+
+Place the file in the project root (or update `CLIENT_SECRETS_FILE` in
+`src/calendar_sync.py`) and ensure the OAuth consent screen includes the
+callback URL `http://localhost:5000/oauth2callback` if using a web flow.
+
+Once credentials are configured you can authorize and sync a user's calendar
+from the CLI using the "Sync Google Calendar" option or by calling the API
+endpoint `/users/<user_id>/calendar/sync`.

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from sqlalchemy.exc import SQLAlchemyError
 import os # For secret key
 
 from src import auth, user, shift, child, event # Models
-from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
+from src import shift_manager, child_manager, event_manager, shift_pattern_manager, calendar_sync # Managers
 from src.database import init_db, SessionLocal
 # Import residency_period model for init_db
 from src import residency_period
@@ -825,6 +825,13 @@ def api_get_child_residency_on_date(child_id):
         return jsonify(message="An unexpected error occurred."), 500
     finally:
         db.close()
+
+# --- Google Calendar Endpoints ---
+
+@app.route('/users/<int:user_id>/calendar/sync', methods=['POST'])
+def api_sync_calendar(user_id):
+    events = calendar_sync.sync_user_calendar(user_id)
+    return jsonify(message="Calendar synced", events=len(events)), 200
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from src import auth, shift_manager, child_manager, event_manager
+from src import auth, shift_manager, child_manager, event_manager, calendar_sync
 
 current_user = None # Store User object or user_id
 
@@ -21,7 +21,8 @@ def display_main_menu():
         # Option 9 (View Child Events) might be too specific for this initial CLI,
         # but including for completeness based on example.
         print("9. View My Child Events (Specify Child ID)")
-        print("10. Logout")
+        print("10. Sync Google Calendar")
+        print("11. Logout")
     print("0. Exit")
     return input("Choose an option: ")
 
@@ -193,6 +194,17 @@ def handle_view_my_child_events():
     for event in events:
         print(f"ID: {event.event_id}, Title: {event.title}, Start: {event.start_time}, End: {event.end_time}, Desc: {event.description}")
 
+def handle_sync_calendar():
+    if not current_user:
+        print("Error: You must be logged in to sync calendar.")
+        return
+    # Start OAuth flow if token is missing
+    if not getattr(current_user, 'calendar_token', None):
+        print("No Google credentials stored. Starting authorization...")
+        calendar_sync.authorize_user(current_user.id)
+    calendar_sync.sync_user_calendar(current_user.id)
+    print("Calendar synced.")
+
 
 if __name__ == "__main__":
     # Initialize the database (create tables if they don't exist)
@@ -239,7 +251,9 @@ if __name__ == "__main__":
             elif choice == '9':
                 handle_view_my_child_events()
             elif choice == '10':
-                auth.logout() # Assuming auth.logout() is defined and handles state
+                handle_sync_calendar()
+            elif choice == '11':
+                auth.logout()  # Assuming auth.logout() is defined and handles state
                 current_user = None
                 print("Logged out successfully.")
             elif choice == '0':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 SQLAlchemy
 pytest
+google-api-python-client
+google-auth-oauthlib

--- a/src/calendar_sync.py
+++ b/src/calendar_sync.py
@@ -1,0 +1,88 @@
+import json
+from datetime import datetime
+from typing import List
+
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.database import SessionLocal
+from src.user import User
+from src.event_manager import create_event
+
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+CLIENT_SECRETS_FILE = 'credentials.json'
+
+
+def _store_credentials(user: User, creds: Credentials, db):
+    """Persist the OAuth credentials JSON for a user."""
+    user.calendar_token = creds.to_json()
+    db.commit()
+
+
+def authorize_user(user_id: int) -> Credentials:
+    """Run local OAuth flow and store the resulting credentials."""
+    db = SessionLocal()
+    try:
+        user_obj = db.query(User).filter(User.id == user_id).first()
+        if not user_obj:
+            print('User not found')
+            return None
+        flow = InstalledAppFlow.from_client_secrets_file(CLIENT_SECRETS_FILE, SCOPES)
+        creds = flow.run_local_server(port=0)
+        _store_credentials(user_obj, creds, db)
+        return creds
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f'DB error during OAuth: {e}')
+        return None
+    finally:
+        db.close()
+
+
+def _credentials_from_user(user: User):
+    if not user.calendar_token:
+        return None
+    return Credentials.from_authorized_user_info(json.loads(user.calendar_token), SCOPES)
+
+
+def fetch_events(user: User) -> List[dict]:
+    """Fetch upcoming events from the user's primary Google Calendar."""
+    creds = _credentials_from_user(user)
+    if not creds:
+        print('No stored OAuth token for user')
+        return []
+    service = build('calendar', 'v3', credentials=creds)
+    now = datetime.utcnow().isoformat() + 'Z'
+    events_result = (
+        service.events()
+        .list(calendarId='primary', timeMin=now, maxResults=10, singleEvents=True, orderBy='startTime')
+        .execute()
+    )
+    return events_result.get('items', [])
+
+
+def sync_user_calendar(user_id: int) -> List[dict]:
+    """Fetch Google events and create matching internal events."""
+    db = SessionLocal()
+    try:
+        user_obj = db.query(User).filter(User.id == user_id).first()
+        if not user_obj:
+            print('User not found')
+            return []
+
+        events = fetch_events(user_obj)
+        for ev in events:
+            summary = ev.get('summary', 'No Title')
+            description = ev.get('description')
+            start = ev['start'].get('dateTime', ev['start'].get('date'))
+            end = ev['end'].get('dateTime', ev['end'].get('date'))
+            if 'T' in start:
+                start = start.replace('T', ' ')[:16]
+            if 'T' in end:
+                end = end.replace('T', ' ')[:16]
+            create_event(summary, description, start, end, linked_user_id=user_id)
+        return events
+    finally:
+        db.close()

--- a/src/user.py
+++ b/src/user.py
@@ -15,6 +15,7 @@ class User(Base):
     name = Column(String, index=True)
     email = Column(String, unique=True, index=True)
     hashed_password = Column(String) # Storing hashed password
+    calendar_token = Column(String, nullable=True)  # OAuth token for Google Calendar
 
     # Relationship to Shifts (One-to-Many: User has many Shifts)
     shifts = relationship("Shift", back_populates="owner")


### PR DESCRIPTION
## Summary
- add Google OAuth token to `User`
- implement `calendar_sync` module for Google Calendar sync
- add calendar sync CLI command
- expose a `/users/<id>/calendar/sync` API endpoint
- document Google Calendar setup
- include Google API dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddef2e4c832aa696c913e660a735