### PR TITLE
Add server-sent event notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ pytest
 ```
 
 This will execute the unit tests for the API and manager modules.
+
+## Notifications
+
+The application exposes a server-sent events endpoint at `/notifications/stream`.
+Authenticated web clients automatically subscribe and will receive JSON messages
+when shifts or events are created or updated. Mobile clients can listen to this
+endpoint to display real-time notifications.

--- a/app.py
+++ b/app.py
@@ -1,9 +1,10 @@
-from flask import Flask, request, jsonify, render_template, redirect, url_for, session, flash
+from flask import Flask, request, jsonify, render_template, redirect, url_for, session, flash, Response
 from sqlalchemy.exc import SQLAlchemyError
 import os # For secret key
 
 from src import auth, user, shift, child, event # Models
 from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
+from src.notification import get_user_queue
 from src.database import init_db, SessionLocal
 # Import residency_period model for init_db
 from src import residency_period
@@ -485,6 +486,21 @@ def logout():
     session.pop('user_name', None)
     flash('You have been successfully logged out.', 'success')
     return redirect(url_for('index'))
+
+@app.route('/notifications/stream')
+def notifications_stream():
+    if 'user_id' not in session:
+        return "Unauthorized", 401
+
+    user_id = session['user_id']
+    q = get_user_queue(user_id)
+
+    def event_stream():
+        while True:
+            data = q.get()
+            yield f"data: {data}\n\n"
+
+    return Response(event_stream(), mimetype='text/event-stream')
 
 # --- Shift Web Routes ---
 

--- a/src/event_manager.py
+++ b/src/event_manager.py
@@ -2,6 +2,10 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from datetime import datetime
+import json
+
+from src.notification import send_notification
+from src.child import Child
 
 from src.database import SessionLocal
 from src.event import Event
@@ -44,6 +48,20 @@ def create_event(title: str, description: str, start_time_str: str, end_time_str
         db.add(new_event)
         db.commit()
         db.refresh(new_event)
+        # Notify linked user or parents of linked child
+        if new_event.user_id:
+            send_notification(new_event.user_id, {
+                "type": "event_created",
+                "event": new_event.to_dict(include_user=False, include_child=False)
+            })
+        elif new_event.child_id:
+            child = db.query(Child).filter(Child.id == new_event.child_id).first()
+            if child:
+                for parent in child.parents:
+                    send_notification(parent.id, {
+                        "type": "event_created",
+                        "event": new_event.to_dict(include_user=False, include_child=False)
+                    })
         return new_event
     except SQLAlchemyError as e:
         db.rollback()
@@ -137,6 +155,19 @@ def update_event(event_id: int, title: str = None, description: str = None,
         if updated:
             db.commit()
             db.refresh(event)
+            if event.user_id:
+                send_notification(event.user_id, {
+                    "type": "event_updated",
+                    "event": event.to_dict(include_user=False, include_child=False)
+                })
+            elif event.child_id:
+                child = db.query(Child).filter(Child.id == event.child_id).first()
+                if child:
+                    for parent in child.parents:
+                        send_notification(parent.id, {
+                            "type": "event_updated",
+                            "event": event.to_dict(include_user=False, include_child=False)
+                        })
         return event
     except SQLAlchemyError as e:
         db.rollback()

--- a/src/notification.py
+++ b/src/notification.py
@@ -1,0 +1,23 @@
+import queue
+from collections import defaultdict
+import json
+from src.database import SessionLocal
+from src.user import User
+
+# Queues per user for SSE messages
+_user_queues = defaultdict(queue.Queue)
+
+def get_user_queue(user_id: int):
+    """Return the Queue object for a user."""
+    return _user_queues[user_id]
+
+def send_notification(user_id: int, message: dict):
+    """Send a notification to a user if they have SSE enabled."""
+    db = SessionLocal()
+    try:
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user or not getattr(user, "prefers_sse", True):
+            return
+    finally:
+        db.close()
+    _user_queues[user_id].put(json.dumps(message))

--- a/src/shift_manager.py
+++ b/src/shift_manager.py
@@ -2,6 +2,9 @@
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from datetime import datetime # For string to datetime conversion
+import json
+
+from src.notification import send_notification
 
 from src.database import SessionLocal
 from src.shift import Shift
@@ -39,6 +42,10 @@ def add_shift(user_id: int, start_time_str: str, end_time_str: str, name: str):
         db.add(new_shift)
         db.commit()
         db.refresh(new_shift)
+        send_notification(user_id, {
+            "type": "shift_created",
+            "shift": new_shift.to_dict(include_owner=False)
+        })
         return new_shift
     except SQLAlchemyError as e:
         db.rollback()
@@ -89,6 +96,10 @@ def update_shift(shift_id: int, new_start_time_str: str = None, new_end_time_str
         if updated:
             db.commit()
             db.refresh(shift)
+            send_notification(shift.user_id, {
+                "type": "shift_updated",
+                "shift": shift.to_dict(include_owner=False)
+            })
         return shift
     except SQLAlchemyError as e:
         db.rollback()

--- a/src/user.py
+++ b/src/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Table, ForeignKey
+from sqlalchemy import Column, Integer, String, Table, ForeignKey, Boolean
 from sqlalchemy.orm import relationship
 from src.database import Base
 
@@ -15,6 +15,8 @@ class User(Base):
     name = Column(String, index=True)
     email = Column(String, unique=True, index=True)
     hashed_password = Column(String) # Storing hashed password
+    prefers_sse = Column(Boolean, default=True)
+    prefers_email = Column(Boolean, default=False)
 
     # Relationship to Shifts (One-to-Many: User has many Shifts)
     shifts = relationship("Shift", back_populates="owner")
@@ -50,7 +52,9 @@ class User(Base):
         data = {
             "id": self.id,
             "name": self.name,
-            "email": self.email
+            "email": self.email,
+            "prefers_sse": self.prefers_sse,
+            "prefers_email": self.prefers_email
             # Exclude hashed_password for security
         }
         if include_shifts and self.shifts: # Check if self.shifts is not None

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -50,5 +50,13 @@
         {% endwith %}
         {% block content %}{% endblock %}
     </div>
+    {% if session.get('user_id') %}
+    <script>
+        const evt = new EventSource("{{ url_for('notifications_stream') }}");
+        evt.onmessage = (e) => {
+            alert("Notification: " + e.data);
+        };
+    </script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce notification queues and SSE endpoint
- add per-user notification preferences
- emit notifications from event and shift managers
- subscribe to notifications from the web UI
- document notifications in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddf0f2c8832aa6a0d1d18f0f03f8