### PR TITLE
Add residency change workflow and expenses

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,8 +2,8 @@ from flask import Flask, request, jsonify, render_template, redirect, url_for, s
 from sqlalchemy.exc import SQLAlchemyError
 import os # For secret key
 
-from src import auth, user, shift, child, event # Models
-from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
+from src import auth, user, shift, child, event, expense # Models
+from src import shift_manager, child_manager, event_manager, shift_pattern_manager, expense_manager # Managers
 from src.database import init_db, SessionLocal
 # Import residency_period model for init_db
 from src import residency_period
@@ -12,7 +12,7 @@ from src import residency_period
 # This should be called once when the application starts.
 try:
     # Import models to ensure they are registered with Base before init_db() is called
-    from src import user, shift, child, event # Models
+    from src import user, shift, child, event, expense
     # Import residency_period model for init_db
     from src import residency_period
     from datetime import datetime # For HTML form datetime-local conversion
@@ -618,6 +618,55 @@ def add_event_web():
     return redirect(url_for('events_view'))
 
 
+# --- Expense Web Routes ---
+
+@app.route('/expenses', methods=['GET'])
+def expenses_view():
+    if 'user_id' not in session:
+        flash('Please login to view expenses.', 'warning')
+        return redirect(url_for('login'))
+
+    user_id = session['user_id']
+    expenses_list = expense_manager.get_all_expenses()
+    children = child_manager.get_user_children(user_id=user_id)
+    return render_template('expenses.html', expenses=expenses_list, children=children)
+
+
+@app.route('/expenses', methods=['POST'])
+def add_expense():
+    if 'user_id' not in session:
+        flash('Please login to add an expense.', 'warning')
+        return redirect(url_for('login'))
+
+    description = request.form.get('description')
+    amount_str = request.form.get('amount')
+    child_id_str = request.form.get('child_id')
+
+    if not description or not amount_str:
+        flash('Description and amount are required.', 'danger')
+        return redirect(url_for('expenses_view'))
+
+    try:
+        amount = float(amount_str)
+    except ValueError:
+        flash('Invalid amount.', 'danger')
+        return redirect(url_for('expenses_view'))
+
+    child_id = int(child_id_str) if child_id_str and child_id_str.isdigit() else None
+
+    new_exp = expense_manager.add_expense(
+        description=description,
+        amount=amount,
+        paid_by_id=session['user_id'],
+        child_id=child_id
+    )
+    if new_exp:
+        flash('Expense added successfully!', 'success')
+    else:
+        flash('Failed to add expense.', 'danger')
+    return redirect(url_for('expenses_view'))
+
+
 # --- Child Web Routes ---
 
 @app.route('/children', methods=['GET'])
@@ -788,6 +837,87 @@ def api_delete_residency_period(period_id):
         db.rollback()
         print(f"Unexpected error deleting residency period: {e}")
         return jsonify(message="An unexpected error occurred."), 500
+    finally:
+        db.close()
+
+# ----- Residency change request endpoints -----
+
+@app.route('/residency-periods/<int:period_id>/propose-change', methods=['POST'])
+def api_propose_residency_change(period_id):
+    data = request.get_json()
+    if not data:
+        return jsonify(message="No change data provided"), 400
+
+    db = SessionLocal()
+    try:
+        period = child_manager.get_residency_period_details(db_session=db, period_id=period_id)
+        if not period:
+            return jsonify(message="Residency period not found"), 404
+
+        period.proposed_start_datetime = child_manager._parse_datetime_for_residency(data.get('start_datetime')) if data.get('start_datetime') else None
+        period.proposed_end_datetime = child_manager._parse_datetime_for_residency(data.get('end_datetime')) if data.get('end_datetime') else None
+        period.change_notes = data.get('notes')
+        period.approval_status = 'pending'
+        db.commit()
+        db.refresh(period)
+        return jsonify(period.to_dict()), 200
+    except Exception as e:
+        db.rollback()
+        print(f"Error proposing change: {e}")
+        return jsonify(message="Error proposing change"), 500
+    finally:
+        db.close()
+
+
+@app.route('/residency-periods/<int:period_id>/accept-change', methods=['POST'])
+def api_accept_residency_change(period_id):
+    db = SessionLocal()
+    try:
+        period = child_manager.get_residency_period_details(db_session=db, period_id=period_id)
+        if not period:
+            return jsonify(message="Residency period not found"), 404
+
+        if period.proposed_start_datetime:
+            period.start_datetime = period.proposed_start_datetime
+        if period.proposed_end_datetime:
+            period.end_datetime = period.proposed_end_datetime
+        if period.change_notes:
+            period.notes = period.change_notes
+
+        period.proposed_start_datetime = None
+        period.proposed_end_datetime = None
+        period.change_notes = None
+        period.approval_status = 'approved'
+        db.commit()
+        db.refresh(period)
+        return jsonify(period.to_dict()), 200
+    except Exception as e:
+        db.rollback()
+        print(f"Error accepting change: {e}")
+        return jsonify(message="Error accepting change"), 500
+    finally:
+        db.close()
+
+
+@app.route('/residency-periods/<int:period_id>/decline-change', methods=['POST'])
+def api_decline_residency_change(period_id):
+    db = SessionLocal()
+    try:
+        period = child_manager.get_residency_period_details(db_session=db, period_id=period_id)
+        if not period:
+            return jsonify(message="Residency period not found"), 404
+
+        period.proposed_start_datetime = None
+        period.proposed_end_datetime = None
+        period.change_notes = None
+        period.approval_status = 'declined'
+        db.commit()
+        db.refresh(period)
+        return jsonify(period.to_dict()), 200
+    except Exception as e:
+        db.rollback()
+        print(f"Error declining change: {e}")
+        return jsonify(message="Error declining change"), 500
     finally:
         db.close()
 

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from src import auth, shift_manager, child_manager, event_manager
+from src import auth, shift_manager, child_manager, event_manager, expense_manager
 
 current_user = None # Store User object or user_id
 
@@ -21,7 +21,9 @@ def display_main_menu():
         # Option 9 (View Child Events) might be too specific for this initial CLI,
         # but including for completeness based on example.
         print("9. View My Child Events (Specify Child ID)")
-        print("10. Logout")
+        print("10. Add Expense")
+        print("11. View Expenses")
+        print("12. Logout")
     print("0. Exit")
     return input("Choose an option: ")
 
@@ -193,6 +195,36 @@ def handle_view_my_child_events():
     for event in events:
         print(f"ID: {event.event_id}, Title: {event.title}, Start: {event.start_time}, End: {event.end_time}, Desc: {event.description}")
 
+def handle_add_expense():
+    if not current_user:
+        print("Error: You must be logged in to add an expense.")
+        return
+
+    description = input("Expense description: ")
+    amount_input = input("Amount: ")
+    child_id_input = input("Child ID (optional): ")
+    try:
+        amount = float(amount_input)
+    except ValueError:
+        print("Invalid amount.")
+        return
+
+    child_id = int(child_id_input) if child_id_input else None
+    exp = expense_manager.add_expense(description, amount, current_user.user_id, child_id)
+    if exp:
+        print("Expense added successfully.")
+    else:
+        print("Error adding expense.")
+
+def handle_view_expenses():
+    expenses = expense_manager.get_all_expenses()
+    if not expenses:
+        print("No expenses found.")
+        return
+    for exp in expenses:
+        child_part = f" for child {exp.child_id}" if exp.child_id else ""
+        print(f"ID: {exp.id} - {exp.description} - ${exp.amount:.2f}{child_part}")
+
 
 if __name__ == "__main__":
     # Initialize the database (create tables if they don't exist)
@@ -203,7 +235,7 @@ if __name__ == "__main__":
         init_db()
         # You might want to import models here too if init_db needs them to be defined
         # For example, if init_db() itself doesn't import them for Base.metadata.create_all()
-        from src import user, shift, child, event # Ensure models are loaded for init_db
+        from src import user, shift, child, event, expense  # Ensure models are loaded for init_db
     except Exception as e:
         print(f"Error initializing database: {e}")
         # Decide if the app should exit or continue if DB init fails.
@@ -239,6 +271,10 @@ if __name__ == "__main__":
             elif choice == '9':
                 handle_view_my_child_events()
             elif choice == '10':
+                handle_add_expense()
+            elif choice == '11':
+                handle_view_expenses()
+            elif choice == '12':
                 auth.logout() # Assuming auth.logout() is defined and handles state
                 current_user = None
                 print("Logged out successfully.")

--- a/src/expense.py
+++ b/src/expense.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from src.database import Base
+
+class Expense(Base):
+    __tablename__ = 'expenses'
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String, nullable=False)
+    amount = Column(Float, nullable=False)
+    paid_by_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    child_id = Column(Integer, ForeignKey('children.id'), nullable=True)
+    expense_date = Column(DateTime, nullable=False, default=datetime.utcnow)
+    notes = Column(String, nullable=True)
+
+    payer = relationship("User")
+    child = relationship("Child")
+
+    def to_dict(self, include_payer=True, include_child=True):
+        data = {
+            "id": self.id,
+            "description": self.description,
+            "amount": self.amount,
+            "paid_by_id": self.paid_by_id,
+            "child_id": self.child_id,
+            "expense_date": self.expense_date.isoformat() if self.expense_date else None,
+            "notes": self.notes,
+        }
+        if include_payer and self.payer:
+            data["payer"] = {"id": self.payer.id, "name": self.payer.name}
+        if include_child and self.child:
+            data["child"] = {"id": self.child.id, "name": self.child.name}
+        return data
+
+    def __repr__(self):
+        return f"<Expense(id={self.id}, desc='{self.description}', amount={self.amount})>"

--- a/src/expense_manager.py
+++ b/src/expense_manager.py
@@ -1,0 +1,118 @@
+from sqlalchemy.exc import SQLAlchemyError
+from datetime import datetime
+
+from src.database import SessionLocal
+from src.expense import Expense
+
+
+def _parse_datetime(dt_str: str):
+    if not dt_str:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(dt_str, fmt)
+        except ValueError:
+            continue
+    print(f"Warning: Could not parse datetime string: {dt_str}")
+    return None
+
+
+def add_expense(description: str, amount: float, paid_by_id: int, child_id: int = None,
+                expense_date_str: str = None, notes: str = None):
+    db = SessionLocal()
+    try:
+        expense_date = _parse_datetime(expense_date_str) or datetime.utcnow()
+        new_expense = Expense(
+            description=description,
+            amount=amount,
+            paid_by_id=paid_by_id,
+            child_id=child_id,
+            expense_date=expense_date,
+            notes=notes,
+        )
+        db.add(new_expense)
+        db.commit()
+        db.refresh(new_expense)
+        return new_expense
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error adding expense: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def get_expense(expense_id: int):
+    db = SessionLocal()
+    try:
+        return db.query(Expense).filter(Expense.id == expense_id).first()
+    finally:
+        db.close()
+
+
+def get_expenses_for_child(child_id: int):
+    db = SessionLocal()
+    try:
+        return db.query(Expense).filter(Expense.child_id == child_id).all()
+    finally:
+        db.close()
+
+
+def get_all_expenses():
+    db = SessionLocal()
+    try:
+        return db.query(Expense).all()
+    finally:
+        db.close()
+
+
+def update_expense(expense_id: int, description: str = None, amount: float = None,
+                   paid_by_id: int = None, child_id: int = None,
+                   expense_date_str: str = None, notes: str = None):
+    db = SessionLocal()
+    try:
+        exp = db.query(Expense).filter(Expense.id == expense_id).first()
+        if not exp:
+            print("Expense not found")
+            return None
+        if description is not None:
+            exp.description = description
+        if amount is not None:
+            exp.amount = amount
+        if paid_by_id is not None:
+            exp.paid_by_id = paid_by_id
+        if child_id is not None:
+            exp.child_id = child_id
+        if expense_date_str is not None:
+            dt = _parse_datetime(expense_date_str)
+            if dt:
+                exp.expense_date = dt
+        if notes is not None:
+            exp.notes = notes
+        db.commit()
+        db.refresh(exp)
+        return exp
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error updating expense: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def delete_expense(expense_id: int):
+    db = SessionLocal()
+    try:
+        exp = db.query(Expense).filter(Expense.id == expense_id).first()
+        if not exp:
+            return False
+        db.delete(exp)
+        db.commit()
+        return True
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error deleting expense: {e}")
+        return False
+    finally:
+        db.close()
+

--- a/src/residency_period.py
+++ b/src/residency_period.py
@@ -11,6 +11,10 @@ class ResidencyPeriod(Base):
     start_datetime = Column(DateTime, nullable=False)
     end_datetime = Column(DateTime, nullable=False)
     notes = Column(String, nullable=True)
+    approval_status = Column(String, nullable=False, default="pending")
+    proposed_start_datetime = Column(DateTime, nullable=True)
+    proposed_end_datetime = Column(DateTime, nullable=True)
+    change_notes = Column(String, nullable=True)
 
     # Relationships
     child = relationship("Child", back_populates="residency_periods")
@@ -23,7 +27,11 @@ class ResidencyPeriod(Base):
             "parent_id": self.parent_id,
             "start_datetime": self.start_datetime.isoformat() if self.start_datetime else None,
             "end_datetime": self.end_datetime.isoformat() if self.end_datetime else None,
-            "notes": self.notes
+            "notes": self.notes,
+            "approval_status": self.approval_status,
+            "proposed_start_datetime": self.proposed_start_datetime.isoformat() if self.proposed_start_datetime else None,
+            "proposed_end_datetime": self.proposed_end_datetime.isoformat() if self.proposed_end_datetime else None,
+            "change_notes": self.change_notes
         }
         if include_child and self.child:
             data['child'] = {"id": self.child.id, "name": self.child.name}
@@ -32,4 +40,8 @@ class ResidencyPeriod(Base):
         return data
 
     def __repr__(self):
-        return f"<ResidencyPeriod(id={self.id}, child_id={self.child_id}, parent_id={self.parent_id}, start='{self.start_datetime}', end='{self.end_datetime}')>"
+        return (
+            f"<ResidencyPeriod(id={self.id}, child_id={self.child_id}, "
+            f"parent_id={self.parent_id}, start='{self.start_datetime}', "
+            f"end='{self.end_datetime}', status='{self.approval_status}')>"
+        )

--- a/templates/expenses.html
+++ b/templates/expenses.html
@@ -1,0 +1,40 @@
+{% extends "layout.html" %}
+
+{% block title %}Expenses{% endblock %}
+
+{% block content %}
+<h2>Shared Expenses</h2>
+
+{% if expenses %}
+<ul>
+    {% for expense in expenses %}
+    <li>
+        {{ expense.description }} - ${{ '%.2f' % expense.amount }}
+        {% if expense.child %}
+            for {{ expense.child.name }}
+        {% endif %}
+        on {{ expense.expense_date.strftime('%Y-%m-%d') }}
+    </li>
+    {% endfor %}
+</ul>
+{% else %}
+<p>No expenses recorded.</p>
+{% endif %}
+
+<hr>
+<h3>Add Expense</h3>
+<form method="POST" action="{{ url_for('add_expense') }}">
+    <label for="description">Description:</label>
+    <input type="text" id="description" name="description" required>
+    <label for="amount">Amount:</label>
+    <input type="number" step="0.01" id="amount" name="amount" required>
+    <label for="child_id">Child (optional):</label>
+    <select id="child_id" name="child_id">
+        <option value="">-- None --</option>
+        {% for child in children %}
+        <option value="{{ child.id }}">{{ child.name }}</option>
+        {% endfor %}
+    </select>
+    <input type="submit" value="Add Expense">
+</form>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -31,6 +31,7 @@
             <ul>
                 <li><a href="{{ url_for('index') }}">Home</a></li>
                 {% if session.get('user_id') %}
+                    <li><a href="{{ url_for('expenses_view') }}">Expenses</a></li>
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
                     {# Add other authenticated links here, e.g., Profile, Dashboard #}
                 {% else %}


### PR DESCRIPTION
## Summary
- track approval status and proposed changes in `ResidencyPeriod`
- provide endpoints to propose, accept or decline residency changes
- store shared costs via new `Expense` model and manager
- support expenses in web UI and CLI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddf38f88832abd87a37fb21ebccb