### PR TITLE
Add task management feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,8 +2,8 @@ from flask import Flask, request, jsonify, render_template, redirect, url_for, s
 from sqlalchemy.exc import SQLAlchemyError
 import os # For secret key
 
-from src import auth, user, shift, child, event # Models
-from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
+from src import auth, user, shift, child, event, task  # Models
+from src import shift_manager, child_manager, event_manager, shift_pattern_manager, task_manager  # Managers
 from src.database import init_db, SessionLocal
 # Import residency_period model for init_db
 from src import residency_period
@@ -12,7 +12,7 @@ from src import residency_period
 # This should be called once when the application starts.
 try:
     # Import models to ensure they are registered with Base before init_db() is called
-    from src import user, shift, child, event # Models
+    from src import user, shift, child, event, task  # Models
     # Import residency_period model for init_db
     from src import residency_period
     from datetime import datetime # For HTML form datetime-local conversion
@@ -268,6 +268,77 @@ def api_delete_event(event_id):
     if event_manager.delete_event(event_id):
         return jsonify(message="Event deleted successfully"), 200 # Or 204
     return jsonify(message="Event not found or delete failed"), 404
+
+
+# --- Task API Endpoints ---
+
+@app.route('/tasks', methods=['POST'])
+def api_create_task():
+    data = request.get_json()
+    if not data or 'description' not in data:
+        return jsonify(message="Missing description for task"), 400
+
+    new_task_obj = task_manager.create_task(
+        description=data['description'],
+        due_date_str=data.get('due_date'),
+        user_id=data.get('user_id'),
+        event_id=data.get('event_id'),
+    )
+    if new_task_obj:
+        return jsonify(new_task_obj.to_dict()), 201
+    return jsonify(message="Failed to create task"), 400
+
+
+@app.route('/tasks/<int:task_id>', methods=['GET'])
+def api_get_task_details(task_id):
+    task_obj = task_manager.get_task_details(task_id)
+    if task_obj:
+        return jsonify(task_obj.to_dict()), 200
+    return jsonify(message="Task not found"), 404
+
+
+@app.route('/users/<int:user_id>/tasks', methods=['GET'])
+def api_get_user_tasks(user_id):
+    tasks_list = task_manager.get_tasks_for_user(user_id)
+    return jsonify([t.to_dict(include_user=False) for t in tasks_list]), 200
+
+
+@app.route('/events/<int:event_id>/tasks', methods=['GET'])
+def api_get_event_tasks(event_id):
+    tasks_list = task_manager.get_tasks_for_event(event_id)
+    return jsonify([t.to_dict(include_event=False) for t in tasks_list]), 200
+
+
+@app.route('/tasks/<int:task_id>', methods=['PUT'])
+def api_update_task(task_id):
+    data = request.get_json()
+    if not data:
+        return jsonify(message="No data provided for update"), 400
+
+    unlink_user = 'user_id' in data and data['user_id'] is None
+    unlink_event = 'event_id' in data and data['event_id'] is None
+
+    updated_task = task_manager.update_task(
+        task_id=task_id,
+        description=data.get('description'),
+        due_date_str=data.get('due_date'),
+        user_id=data.get('user_id') if not unlink_user else None,
+        event_id=data.get('event_id') if not unlink_event else None,
+        completed=data.get('completed'),
+        unlink_user=unlink_user,
+        unlink_event=unlink_event,
+    )
+    if updated_task:
+        return jsonify(updated_task.to_dict()), 200
+    return jsonify(message="Task not found or update failed"), 404
+
+
+@app.route('/tasks/<int:task_id>', methods=['DELETE'])
+def api_delete_task(task_id):
+    if task_manager.delete_task(task_id):
+        return jsonify(message="Task deleted successfully"), 200
+    return jsonify(message="Task not found or delete failed"), 404
+
 
 
 # --- Shift Pattern API Endpoints ---
@@ -616,6 +687,69 @@ def add_event_web():
         flash('Failed to add event. Please check your input or try again.', 'danger')
 
     return redirect(url_for('events_view'))
+
+
+# --- Task Web Routes ---
+
+@app.route('/tasks', methods=['GET'])
+def tasks_view():
+    if 'user_id' not in session:
+        flash('Please login to view your tasks.', 'warning')
+        return redirect(url_for('login'))
+
+    user_id = session['user_id']
+    user_tasks = task_manager.get_tasks_for_user(user_id=user_id)
+    user_events = event_manager.get_events_for_user(user_id=user_id)
+    return render_template('tasks.html', tasks=user_tasks, events=user_events)
+
+
+@app.route('/tasks/add-web', methods=['POST'])
+def add_task_web():
+    if 'user_id' not in session:
+        flash('Please login to add a task.', 'warning')
+        return redirect(url_for('login'))
+
+    user_id = session['user_id']
+    description = request.form.get('description')
+    due_date_str_html = request.form.get('due_date')
+    event_id_str = request.form.get('event_id')
+
+    if not description:
+        flash('Task description is required.', 'danger')
+        return redirect(url_for('tasks_view'))
+
+    due_date_formatted = None
+    if due_date_str_html:
+        try:
+            due_date_formatted = datetime.fromisoformat(due_date_str_html).strftime('%Y-%m-%d %H:%M')
+        except ValueError:
+            flash('Invalid datetime format submitted for task.', 'danger')
+            return redirect(url_for('tasks_view'))
+
+    linked_event_id = None
+    if event_id_str and event_id_str.isdigit():
+        linked_event_id = int(event_id_str)
+        user_event_ids = [e.id for e in event_manager.get_events_for_user(user_id=user_id)]
+        if linked_event_id not in user_event_ids:
+            flash('Invalid event selected for the task.', 'danger')
+            return redirect(url_for('tasks_view'))
+    elif event_id_str:
+        flash('Invalid event ID format.', 'danger')
+        return redirect(url_for('tasks_view'))
+
+    new_task = task_manager.create_task(
+        description=description,
+        due_date_str=due_date_formatted,
+        user_id=user_id,
+        event_id=linked_event_id
+    )
+
+    if new_task:
+        flash('Task added successfully!', 'success')
+    else:
+        flash('Failed to add task. Please try again.', 'danger')
+
+    return redirect(url_for('tasks_view'))
 
 
 # --- Child Web Routes ---

--- a/src/task.py
+++ b/src/task.py
@@ -1,0 +1,35 @@
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
+from src.database import Base
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    description = Column(String, nullable=False)
+    due_date = Column(DateTime, nullable=True)
+    completed = Column(Boolean, default=False)
+
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+    event_id = Column(Integer, ForeignKey("events.id"), nullable=True)
+
+    user = relationship("User")
+    event = relationship("Event")
+
+    def __repr__(self):
+        return f"<Task(id={self.id}, description='{self.description}')>"
+
+    def to_dict(self, include_user=True, include_event=True):
+        data = {
+            "id": self.id,
+            "description": self.description,
+            "due_date": self.due_date.isoformat() if self.due_date else None,
+            "completed": self.completed,
+            "user_id": self.user_id,
+            "event_id": self.event_id,
+        }
+        if include_user and self.user:
+            data["user"] = {"id": self.user.id, "name": self.user.name}
+        if include_event and self.event:
+            data["event"] = {"id": self.event.id, "title": self.event.title}
+        return data

--- a/src/task_manager.py
+++ b/src/task_manager.py
@@ -1,0 +1,133 @@
+from datetime import datetime
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.database import SessionLocal
+from src.task import Task
+
+
+def _parse_datetime(datetime_str):
+    if not datetime_str:
+        return None
+    try:
+        return datetime.strptime(datetime_str, '%Y-%m-%d %H:%M')
+    except ValueError:
+        print(f"Warning: Could not parse datetime string: {datetime_str}")
+        return None
+
+
+def create_task(description, due_date_str=None, user_id=None, event_id=None):
+    db = SessionLocal()
+    try:
+        due_dt = _parse_datetime(due_date_str) if due_date_str else None
+        new_task = Task(
+            description=description,
+            due_date=due_dt,
+            user_id=user_id,
+            event_id=event_id,
+            completed=False,
+        )
+        db.add(new_task)
+        db.commit()
+        db.refresh(new_task)
+        return new_task
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error creating task: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def get_task_details(task_id):
+    db = SessionLocal()
+    try:
+        return db.query(Task).filter(Task.id == task_id).first()
+    except SQLAlchemyError as e:
+        print(f"Database error getting task details: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def get_tasks_for_user(user_id):
+    db = SessionLocal()
+    try:
+        return db.query(Task).filter(Task.user_id == user_id).all()
+    except SQLAlchemyError as e:
+        print(f"Database error getting tasks for user: {e}")
+        return []
+    finally:
+        db.close()
+
+
+def get_tasks_for_event(event_id):
+    db = SessionLocal()
+    try:
+        return db.query(Task).filter(Task.event_id == event_id).all()
+    except SQLAlchemyError as e:
+        print(f"Database error getting tasks for event: {e}")
+        return []
+    finally:
+        db.close()
+
+
+def update_task(task_id, description=None, due_date_str=None, user_id=None, event_id=None, completed=None, unlink_user=False, unlink_event=False):
+    db = SessionLocal()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if not task:
+            print("Error: Task not found.")
+            return None
+
+        updated = False
+        if description is not None:
+            task.description = description
+            updated = True
+        if due_date_str is not None:
+            due_dt = _parse_datetime(due_date_str)
+            if due_dt:
+                task.due_date = due_dt
+                updated = True
+        if unlink_user:
+            task.user_id = None
+            updated = True
+        elif user_id is not None:
+            task.user_id = user_id
+            updated = True
+        if unlink_event:
+            task.event_id = None
+            updated = True
+        elif event_id is not None:
+            task.event_id = event_id
+            updated = True
+        if completed is not None:
+            task.completed = bool(completed)
+            updated = True
+        if updated:
+            db.commit()
+            db.refresh(task)
+        return task
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error updating task: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def delete_task(task_id):
+    db = SessionLocal()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).first()
+        if not task:
+            print("Error: Task not found for deletion.")
+            return False
+        db.delete(task)
+        db.commit()
+        return True
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error deleting task: {e}")
+        return False
+    finally:
+        db.close()

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,0 +1,51 @@
+{% extends "layout.html" %}
+
+{% block title %}My Tasks{% endblock %}
+
+{% block content %}
+    <h2>My Tasks</h2>
+
+    {% if tasks %}
+        <ul>
+            {% for task in tasks %}
+                <li>
+                    <input type="checkbox" disabled {% if task.completed %}checked{% endif %}> {{ task.description }}
+                    {% if task.due_date %}
+                        <small>Due: {{ task.due_date.strftime('%Y-%m-%d %H:%M') }}</small>
+                    {% endif %}
+                    {% if task.event_id %}
+                        <br><small>Event ID {{ task.event_id }}{% if task.event %} ({{ task.event.title }}){% endif %}</small>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>You have no tasks.</p>
+    {% endif %}
+
+    <hr>
+
+    <h3>Add New Task</h3>
+    <form method="POST" action="{{ url_for('add_task_web') }}">
+        <div>
+            <label for="description">Task Description:</label>
+            <input type="text" id="description" name="description" required>
+        </div>
+        <div>
+            <label for="due_date">Due Date (optional):</label>
+            <input type="datetime-local" id="due_date" name="due_date">
+        </div>
+        <div>
+            <label for="event_id">Link to Event (Optional):</label>
+            <select id="event_id" name="event_id">
+                <option value="">-- None --</option>
+                {% for event in events %}
+                    <option value="{{ event.id }}">{{ event.title }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <input type="submit" value="Add Task">
+        </div>
+    </form>
+{% endblock %}

--- a/tests/test_api_tasks.py
+++ b/tests/test_api_tasks.py
@@ -1,0 +1,123 @@
+import unittest
+import os
+import hashlib
+import sys
+from datetime import datetime
+
+sys_path_updated = False
+if os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) not in sys.path:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    sys_path_updated = True
+
+os.environ["TEST_MODE_ENABLED"] = "1"
+
+from app import app
+from src.database import initialize_database_for_application, create_tables, drop_tables, SessionLocal
+from src.user import User
+from src.event import Event
+from src.task import Task
+
+class TestAPITasks(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        initialize_database_for_application()
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        app.config['SECRET_KEY'] = 'test_secret_key_tasks'
+        from src import user, shift, child, event, task, shift_pattern, residency_period
+        create_tables()
+
+    @classmethod
+    def tearDownClass(cls):
+        drop_tables()
+        if "TEST_MODE_ENABLED" in os.environ:
+            del os.environ["TEST_MODE_ENABLED"]
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.db = SessionLocal()
+        self.db.query(Task).delete()
+        self.db.query(Event).delete()
+        self.db.query(User).delete()
+        self.db.commit()
+
+        self.user = self._create_user("Task User", "taskuser@example.com", "pass")
+        self.event = self._create_event_for_user(self.user.id, "Task Event")
+
+    def tearDown(self):
+        self.db.query(Task).delete()
+        self.db.query(Event).delete()
+        self.db.query(User).delete()
+        self.db.commit()
+        self.db.close()
+
+    def _create_user(self, name, email, password):
+        hashed = hashlib.sha256(password.encode()).hexdigest()
+        user = User(name=name, email=email, hashed_password=hashed)
+        self.db.add(user)
+        self.db.commit()
+        self.db.refresh(user)
+        return user
+
+    def _create_event_for_user(self, user_id, title):
+        event = Event(title=title, start_time=datetime(2024,1,1,10,0), end_time=datetime(2024,1,1,11,0), user_id=user_id)
+        self.db.add(event)
+        self.db.commit()
+        self.db.refresh(event)
+        return event
+
+    def _create_task_api(self, description, due_date=None, user_id=None, event_id=None):
+        payload = {"description": description}
+        if due_date:
+            payload["due_date"] = due_date
+        if user_id:
+            payload["user_id"] = user_id
+        if event_id:
+            payload["event_id"] = event_id
+        return self.client.post('/tasks', json=payload)
+
+    # --- Tests ---
+    def test_create_task_for_user_success(self):
+        response = self._create_task_api("Buy milk", user_id=self.user.id)
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertEqual(data['description'], "Buy milk")
+        self.assertEqual(data['user_id'], self.user.id)
+        task_in_db = self.db.query(Task).get(data['id'])
+        self.assertIsNotNone(task_in_db)
+
+    def test_get_task_details_success(self):
+        res = self._create_task_api("Do homework", user_id=self.user.id, event_id=self.event.id)
+        task_id = res.get_json()['id']
+        response = self.client.get(f'/tasks/{task_id}')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(data['id'], task_id)
+        self.assertEqual(data['event_id'], self.event.id)
+
+    def test_get_tasks_for_user(self):
+        self._create_task_api("A", user_id=self.user.id)
+        self._create_task_api("B", user_id=self.user.id)
+        response = self.client.get(f'/users/{self.user.id}/tasks')
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertEqual(len(data), 2)
+
+    def test_update_task_completion(self):
+        res = self._create_task_api("Finish project", user_id=self.user.id)
+        task_id = res.get_json()['id']
+        response = self.client.put(f'/tasks/{task_id}', json={"completed": True})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()['completed'])
+        self.assertTrue(self.db.query(Task).get(task_id).completed)
+
+    def test_delete_task(self):
+        res = self._create_task_api("Old Task", user_id=self.user.id)
+        task_id = res.get_json()['id']
+        response = self.client.delete(f'/tasks/{task_id}')
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(self.db.query(Task).get(task_id))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `Task` model and manager
- add `/tasks` API and web routes
- render tasks page with creation form
- test task endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask/sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6840ddf55e44832a86c6e164513d0e74