### PR TITLE
Add booking support with calendar integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,8 +2,8 @@ from flask import Flask, request, jsonify, render_template, redirect, url_for, s
 from sqlalchemy.exc import SQLAlchemyError
 import os # For secret key
 
-from src import auth, user, shift, child, event # Models
-from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
+from src import auth, user, shift, child, event, booking # Models
+from src import shift_manager, child_manager, event_manager, shift_pattern_manager, booking_manager # Managers
 from src.database import init_db, SessionLocal
 # Import residency_period model for init_db
 from src import residency_period
@@ -12,7 +12,7 @@ from src import residency_period
 # This should be called once when the application starts.
 try:
     # Import models to ensure they are registered with Base before init_db() is called
-    from src import user, shift, child, event # Models
+    from src import user, shift, child, event, booking # Models
     # Import residency_period model for init_db
     from src import residency_period
     from datetime import datetime # For HTML form datetime-local conversion
@@ -271,6 +271,57 @@ def api_delete_event(event_id):
 
 
 # --- Shift Pattern API Endpoints ---
+
+@app.route('/bookings', methods=['POST'])
+def api_create_booking():
+    data = request.get_json()
+    if not data or not all(k in data for k in ('service', 'start_time', 'end_time', 'user_id')):
+        return jsonify(message="Missing required booking fields"), 400
+
+    booking_obj = booking_manager.create_booking(
+        service=data['service'],
+        start_time_str=data['start_time'],
+        end_time_str=data['end_time'],
+        user_id=data['user_id']
+    )
+    if booking_obj:
+        return jsonify(booking_obj.to_dict()), 201
+    return jsonify(message="Failed to create booking"), 400
+
+@app.route('/bookings/<int:booking_id>', methods=['GET'])
+def api_get_booking_details(booking_id):
+    booking = booking_manager.get_booking_details(booking_id)
+    if booking:
+        return jsonify(booking.to_dict()), 200
+    return jsonify(message="Booking not found"), 404
+
+@app.route('/users/<int:user_id>/bookings', methods=['GET'])
+def api_get_user_bookings(user_id):
+    bookings = booking_manager.get_bookings_for_user(user_id)
+    return jsonify([b.to_dict(include_user=False) for b in bookings]), 200
+
+@app.route('/bookings/<int:booking_id>', methods=['PUT'])
+def api_update_booking(booking_id):
+    data = request.get_json()
+    if not data:
+        return jsonify(message="No data provided for update"), 400
+
+    updated = booking_manager.update_booking(
+        booking_id=booking_id,
+        service=data.get('service'),
+        start_time_str=data.get('start_time'),
+        end_time_str=data.get('end_time')
+    )
+    if updated:
+        return jsonify(updated.to_dict()), 200
+    return jsonify(message="Booking not found or update failed"), 404
+
+@app.route('/bookings/<int:booking_id>', methods=['DELETE'])
+def api_delete_booking(booking_id):
+    if booking_manager.delete_booking(booking_id):
+        return jsonify(message="Booking deleted successfully"), 200
+    return jsonify(message="Booking not found or delete failed"), 404
+
 
 @app.route('/shift-patterns', methods=['POST'])
 def api_create_global_shift_pattern():
@@ -617,6 +668,53 @@ def add_event_web():
 
     return redirect(url_for('events_view'))
 
+
+
+# --- Booking Web Routes ---
+@app.route('/bookings', methods=['GET'])
+def bookings_view():
+    if 'user_id' not in session:
+        flash('Please login to view your bookings.', 'warning')
+        return redirect(url_for('login'))
+
+    user_id = session['user_id']
+    user_bookings = booking_manager.get_bookings_for_user(user_id=user_id)
+    return render_template('bookings.html', bookings=user_bookings)
+
+@app.route('/bookings/add-web', methods=['POST'])
+def add_booking_web():
+    if 'user_id' not in session:
+        flash('Please login to add a booking.', 'warning')
+        return redirect(url_for('login'))
+
+    user_id = session['user_id']
+    service = request.form.get('service')
+    start_time_str_html = request.form.get('start_time')
+    end_time_str_html = request.form.get('end_time')
+
+    if not service or not start_time_str_html or not end_time_str_html:
+        flash('All fields are required for a booking.', 'danger')
+        return redirect(url_for('bookings_view'))
+
+    try:
+        start_formatted = datetime.fromisoformat(start_time_str_html).strftime('%Y-%m-%d %H:%M')
+        end_formatted = datetime.fromisoformat(end_time_str_html).strftime('%Y-%m-%d %H:%M')
+    except ValueError:
+        flash('Invalid datetime format submitted for booking.', 'danger')
+        return redirect(url_for('bookings_view'))
+
+    new_booking = booking_manager.create_booking(
+        service=service,
+        start_time_str=start_formatted,
+        end_time_str=end_formatted,
+        user_id=user_id
+    )
+    if new_booking:
+        flash('Booking added successfully!', 'success')
+    else:
+        flash('Failed to add booking. Please try again.', 'danger')
+
+    return redirect(url_for('bookings_view'))
 
 # --- Child Web Routes ---
 

--- a/src/booking.py
+++ b/src/booking.py
@@ -1,0 +1,35 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from src.database import Base
+
+class Booking(Base):
+    __tablename__ = "bookings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    service = Column(String, index=True)
+    start_time = Column(DateTime)
+    end_time = Column(DateTime)
+
+    user_id = Column(Integer, ForeignKey("users.id"))
+    event_id = Column(Integer, ForeignKey("events.id"), nullable=True)
+
+    user = relationship("User")
+    event = relationship("Event")
+
+    def __repr__(self):
+        return f"<Booking(id={self.id}, service='{self.service}')>"
+
+    def to_dict(self, include_user=True, include_event=True):
+        data = {
+            "id": self.id,
+            "service": self.service,
+            "start_time": self.start_time.isoformat() if self.start_time else None,
+            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "user_id": self.user_id,
+            "event_id": self.event_id,
+        }
+        if include_user and self.user:
+            data["user"] = {"id": self.user.id, "name": self.user.name}
+        if include_event and self.event:
+            data["event"] = {"id": self.event.id, "title": self.event.title}
+        return data

--- a/src/booking_manager.py
+++ b/src/booking_manager.py
@@ -1,0 +1,132 @@
+from sqlalchemy.exc import SQLAlchemyError
+from datetime import datetime
+
+from src.database import SessionLocal
+from src.booking import Booking
+from src import event_manager
+
+
+def _parse_datetime(dt_str: str):
+    if not dt_str:
+        return None
+    try:
+        return datetime.strptime(dt_str, "%Y-%m-%d %H:%M")
+    except ValueError:
+        print(f"Warning: Could not parse datetime string: {dt_str}")
+        return None
+
+
+def create_booking(service: str, start_time_str: str, end_time_str: str, user_id: int):
+    db = SessionLocal()
+    try:
+        start_dt = _parse_datetime(start_time_str)
+        end_dt = _parse_datetime(end_time_str)
+        if not start_dt or not end_dt:
+            print("Error: Invalid start or end time format for booking.")
+            return None
+        booking = Booking(service=service, start_time=start_dt, end_time=end_dt, user_id=user_id)
+        db.add(booking)
+        db.commit()
+        db.refresh(booking)
+
+        event = event_manager.create_event(
+            title=f"Booking: {service}",
+            description=f"Service booking for {service}",
+            start_time_str=start_time_str,
+            end_time_str=end_time_str,
+            linked_user_id=user_id,
+            linked_child_id=None,
+        )
+        if event:
+            booking.event_id = event.id
+            db.commit()
+            db.refresh(booking)
+        return booking
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error creating booking: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def get_booking_details(booking_id: int):
+    db = SessionLocal()
+    try:
+        return db.query(Booking).filter(Booking.id == booking_id).first()
+    except SQLAlchemyError as e:
+        print(f"Database error getting booking details: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def get_bookings_for_user(user_id: int):
+    db = SessionLocal()
+    try:
+        return db.query(Booking).filter(Booking.user_id == user_id).all()
+    except SQLAlchemyError as e:
+        print(f"Database error getting bookings for user: {e}")
+        return []
+    finally:
+        db.close()
+
+
+def update_booking(booking_id: int, service: str = None, start_time_str: str = None, end_time_str: str = None):
+    db = SessionLocal()
+    try:
+        booking = db.query(Booking).filter(Booking.id == booking_id).first()
+        if not booking:
+            print("Error: Booking not found.")
+            return None
+        updated = False
+        if service is not None:
+            booking.service = service
+            updated = True
+        if start_time_str is not None:
+            st = _parse_datetime(start_time_str)
+            if st:
+                booking.start_time = st
+                updated = True
+        if end_time_str is not None:
+            et = _parse_datetime(end_time_str)
+            if et:
+                booking.end_time = et
+                updated = True
+        if updated:
+            db.commit()
+            db.refresh(booking)
+            if booking.event_id:
+                event_manager.update_event(
+                    booking.event_id,
+                    title=f"Booking: {booking.service}",
+                    start_time_str=start_time_str or booking.start_time.strftime("%Y-%m-%d %H:%M"),
+                    end_time_str=end_time_str or booking.end_time.strftime("%Y-%m-%d %H:%M"),
+                )
+        return booking
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error updating booking: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def delete_booking(booking_id: int):
+    db = SessionLocal()
+    try:
+        booking = db.query(Booking).filter(Booking.id == booking_id).first()
+        if not booking:
+            print("Error: Booking not found for deletion.")
+            return False
+        if booking.event_id:
+            event_manager.delete_event(booking.event_id)
+        db.delete(booking)
+        db.commit()
+        return True
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error deleting booking: {e}")
+        return False
+    finally:
+        db.close()

--- a/templates/bookings.html
+++ b/templates/bookings.html
@@ -1,0 +1,42 @@
+{% extends "layout.html" %}
+
+{% block title %}My Bookings{% endblock %}
+
+{% block content %}
+    <h2>My Bookings</h2>
+
+    {% if bookings %}
+        <ul>
+            {% for booking in bookings %}
+                <li>
+                    <strong>{{ booking.service }}</strong>:
+                    From {{ booking.start_time.strftime('%Y-%m-%d %H:%M') if booking.start_time else 'N/A' }}
+                    to {{ booking.end_time.strftime('%Y-%m-%d %H:%M') if booking.end_time else 'N/A' }}
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p>You have no bookings.</p>
+    {% endif %}
+
+    <hr>
+
+    <h3>Add New Booking</h3>
+    <form method="POST" action="{{ url_for('add_booking_web') }}">
+        <div>
+            <label for="service">Service:</label>
+            <input type="text" id="service" name="service" required>
+        </div>
+        <div>
+            <label for="start_time">Start Time:</label>
+            <input type="datetime-local" id="start_time" name="start_time" required>
+        </div>
+        <div>
+            <label for="end_time">End Time:</label>
+            <input type="datetime-local" id="end_time" name="end_time" required>
+        </div>
+        <div>
+            <input type="submit" value="Add Booking">
+        </div>
+    </form>
+{% endblock %}

--- a/tests/test_api_bookings.py
+++ b/tests/test_api_bookings.py
@@ -1,0 +1,95 @@
+import unittest
+import os
+import hashlib
+import sys
+
+sys_path_updated = False
+if os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) not in sys.path:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    sys_path_updated = True
+
+os.environ["TEST_MODE_ENABLED"] = "1"
+
+from app import app
+from src.database import initialize_database_for_application, create_tables, drop_tables, SessionLocal
+from src.user import User
+from src.booking import Booking
+from src.event import Event
+
+class TestAPIBookings(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        initialize_database_for_application()
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        app.config['SECRET_KEY'] = 'test_secret_key_bookings'
+        from src import user, shift, child, event, booking, shift_pattern, residency_period
+        create_tables()
+
+    @classmethod
+    def tearDownClass(cls):
+        drop_tables()
+        if "TEST_MODE_ENABLED" in os.environ:
+            del os.environ["TEST_MODE_ENABLED"]
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.db = SessionLocal()
+        self.db.query(Booking).delete()
+        self.db.query(Event).delete()
+        self.db.query(User).delete()
+        self.db.commit()
+        self.user = self._create_user_directly(email="booker@example.com")
+
+    def tearDown(self):
+        self.db.query(Booking).delete()
+        self.db.query(Event).delete()
+        self.db.query(User).delete()
+        self.db.commit()
+        self.db.close()
+
+    def _create_user_directly(self, name="Book User", email="book@example.com", password="pass"):
+        hashed = hashlib.sha256(password.encode()).hexdigest()
+        u = User(name=name, email=email, hashed_password=hashed)
+        self.db.add(u)
+        self.db.commit()
+        self.db.refresh(u)
+        return u
+
+    def _create_booking_api(self, service="Consult", start="2024-01-01 10:00", end="2024-01-01 11:00", user_id=None):
+        payload = {
+            "service": service,
+            "start_time": start,
+            "end_time": end,
+            "user_id": user_id or self.user.id
+        }
+        return self.client.post('/bookings', json=payload)
+
+    def test_create_booking_creates_event(self):
+        response = self._create_booking_api()
+        self.assertEqual(response.status_code, 201)
+        data = response.get_json()
+        self.assertIn('event_id', data)
+        booking_in_db = self.db.query(Booking).get(data['id'])
+        self.assertIsNotNone(booking_in_db)
+        self.assertIsNotNone(booking_in_db.event_id)
+        event_in_db = self.db.query(Event).get(booking_in_db.event_id)
+        self.assertIsNotNone(event_in_db)
+        self.assertEqual(event_in_db.title, f"Booking: {booking_in_db.service}")
+
+    def test_get_user_bookings(self):
+        self._create_booking_api(service="A")
+        self._create_booking_api(service="B")
+        other_user = self._create_user_directly(name="Other", email="o@example.com")
+        self._create_booking_api(service="C", user_id=other_user.id)
+
+        resp = self.client.get(f'/users/{self.user.id}/bookings')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.get_json()
+        self.assertEqual(len(data), 2)
+        services = {b['service'] for b in data}
+        self.assertIn("A", services)
+        self.assertIn("B", services)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add SQLAlchemy `Booking` model and manager
- implement API and web routes for bookings
- create booking page template
- link bookings to events so they show in the calendar
- add unit tests for booking API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddf93aa8832aab7166d6df2c53a2