### PR TITLE
Add analytics page and CLI export

### DIFF
--- a/analytics_cli.py
+++ b/analytics_cli.py
@@ -1,0 +1,16 @@
+import argparse
+from src.analytics import export_monthly_analytics_csv
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Export analytics data to CSV")
+    parser.add_argument('--user', type=int, required=True, help='User ID')
+    parser.add_argument('--output', default='analytics.csv', help='Output CSV file')
+    args = parser.parse_args()
+
+    export_monthly_analytics_csv(args.user, args.output)
+    print(f"Analytics exported to {args.output}")
+
+
+if __name__ == '__main__':
+    main()

--- a/app.py
+++ b/app.py
@@ -3,9 +3,11 @@ from sqlalchemy.exc import SQLAlchemyError
 import os # For secret key
 
 from src import auth, user, shift, child, event # Models
+from datetime import datetime
 from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
 from src.database import init_db, SessionLocal
 # Import residency_period model for init_db
+from src import analytics
 from src import residency_period
 
 # Initialize the database (create tables if they don't exist)
@@ -665,6 +667,16 @@ def add_child_web():
         flash('Failed to add child. Please check your input or try again.', 'danger')
 
     return redirect(url_for('children_view'))
+
+@app.route("/analytics")
+def analytics_view():
+    if "user_id" not in session:
+        flash("Please login to view analytics.", "warning")
+        return redirect(url_for("login"))
+    user_id = session["user_id"]
+    data = analytics.get_monthly_analytics(user_id)
+    return render_template("analytics.html", data=data)
+
 
 
 # The previous residency period POST route:

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -1,0 +1,61 @@
+from sqlalchemy import func
+from .database import SessionLocal
+from .shift import Shift
+from .event import Event
+from .residency_period import ResidencyPeriod
+
+
+def get_monthly_analytics(user_id: int):
+    """Return monthly counts of shifts, events and residency periods for a user."""
+    db = SessionLocal()
+    try:
+        shift_counts = db.query(
+            func.strftime('%Y-%m', Shift.start_time).label('month'),
+            func.count(Shift.id)
+        ).filter(Shift.user_id == user_id).group_by('month').all()
+
+        event_counts = db.query(
+            func.strftime('%Y-%m', Event.start_time).label('month'),
+            func.count(Event.id)
+        ).filter(Event.user_id == user_id).group_by('month').all()
+
+        residency_counts = db.query(
+            func.strftime('%Y-%m', ResidencyPeriod.start_datetime).label('month'),
+            func.count(ResidencyPeriod.id)
+        ).filter(ResidencyPeriod.parent_id == user_id).group_by('month').all()
+
+        data = {
+            'shifts': [{'month': m, 'count': c} for m, c in shift_counts],
+            'events': [{'month': m, 'count': c} for m, c in event_counts],
+            'residency_periods': [{'month': m, 'count': c} for m, c in residency_counts]
+        }
+        return data
+    finally:
+        db.close()
+
+
+def export_monthly_analytics_csv(user_id: int, file_path: str):
+    """Export analytics data to a CSV file."""
+    import csv
+    data = get_monthly_analytics(user_id)
+
+    months = set()
+    for category in data.values():
+        months.update(item['month'] for item in category)
+    months = sorted(months)
+
+    shift_map = {d['month']: d['count'] for d in data['shifts']}
+    event_map = {d['month']: d['count'] for d in data['events']}
+    res_map = {d['month']: d['count'] for d in data['residency_periods']}
+
+    with open(file_path, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['month', 'shifts', 'events', 'residency_periods'])
+        for month in months:
+            writer.writerow([
+                month,
+                shift_map.get(month, 0),
+                event_map.get(month, 0),
+                res_map.get(month, 0)
+            ])
+

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -1,0 +1,36 @@
+{% extends "layout.html" %}
+
+{% block title %}Analytics{% endblock %}
+
+{% block content %}
+<h2>Monthly Analytics</h2>
+<canvas id="shiftsChart" height="100"></canvas>
+<canvas id="eventsChart" height="100"></canvas>
+<canvas id="residencyChart" height="100"></canvas>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    const analyticsData = {{ data | tojson }};
+    function buildDataset(key) {
+        const labels = analyticsData[key].map(item => item.month);
+        const counts = analyticsData[key].map(item => item.count);
+        return {labels: labels, data: counts};
+    }
+    const shifts = buildDataset('shifts');
+    const events = buildDataset('events');
+    const residency = buildDataset('residency_periods');
+
+    new Chart(document.getElementById('shiftsChart'), {
+        type: 'bar',
+        data: {labels: shifts.labels, datasets: [{label: 'Shifts', data: shifts.data, backgroundColor: 'rgba(75, 192, 192, 0.6)'}]}
+    });
+    new Chart(document.getElementById('eventsChart'), {
+        type: 'bar',
+        data: {labels: events.labels, datasets: [{label: 'Events', data: events.data, backgroundColor: 'rgba(54, 162, 235, 0.6)'}]}
+    });
+    new Chart(document.getElementById('residencyChart'), {
+        type: 'bar',
+        data: {labels: residency.labels, datasets: [{label: 'Residency Periods', data: residency.data, backgroundColor: 'rgba(255, 159, 64, 0.6)'}]}
+    });
+</script>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -33,6 +33,7 @@
                 {% if session.get('user_id') %}
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
                     {# Add other authenticated links here, e.g., Profile, Dashboard #}
+                    <li><a href="{{ url_for('analytics_view') }}">Analytics</a></li>
                 {% else %}
                     <li><a href="{{ url_for('login') }}">Login</a></li>
                     <li><a href="{{ url_for('register') }}">Register</a></li>


### PR DESCRIPTION
## Summary
- add monthly analytics utilities and CSV export
- expose `/analytics` web route with Chart.js graphs
- show analytics link in navigation
- provide a CLI script to export analytics as CSV

## Testing
- `python -m py_compile app.py src/analytics.py analytics_cli.py`
- `python -m py_compile src/*.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddfa06c4832a8f1aab8e73d4f496