### PR TITLE
Add user roles with access control

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,6 +56,10 @@ def handle_add_shift():
         print("Error: You must be logged in to add a shift.")
         return
 
+    if getattr(current_user, 'role', 'parent') != 'parent':
+        print("Permission denied: Only parents can add shifts.")
+        return
+
     print("\n--- Add New Shift ---")
     # Assuming current_user is a User object with a user_id attribute
     user_id = current_user.user_id
@@ -86,6 +90,10 @@ def handle_view_my_shifts():
 def handle_add_child():
     if not current_user:
         print("Error: You must be logged in to add a child.")
+        return
+
+    if getattr(current_user, 'role', 'parent') != 'parent':
+        print("Permission denied: Only parents can add children.")
         return
 
     print("\n--- Add New Child ---")
@@ -119,6 +127,10 @@ def handle_view_my_children():
 def handle_create_event():
     if not current_user:
         print("Error: You must be logged in to create an event.")
+        return
+
+    if getattr(current_user, 'role', 'parent') != 'parent':
+        print("Permission denied: Only parents can create events.")
         return
 
     print("\n--- Create New Event ---")

--- a/src/auth.py
+++ b/src/auth.py
@@ -8,7 +8,7 @@ from src.user import User # SQLAlchemy User model
 
 # users_db is removed, data will be stored in SQLite via SQLAlchemy
 
-def register(name, email, password):
+def register(name, email, password, role='parent'):
     db = SessionLocal()
     try:
         # Check if user already exists
@@ -21,7 +21,7 @@ def register(name, email, password):
 
         # Note: User.id is an auto-incrementing Integer PK.
         # The previous user_id (uuid) is not directly used here unless the model changes.
-        new_user = User(name=name, email=email, hashed_password=hashed_password)
+        new_user = User(name=name, email=email, hashed_password=hashed_password, role=role)
 
         db.add(new_user)
         db.commit()
@@ -69,3 +69,15 @@ def logout():
     # For this app, current_user is set to None in main.py.
     print("User logged out (client-side state cleared).")
     pass
+
+def user_has_role(user_or_id, required_role: str) -> bool:
+    """Check if the given user (object or id) has the required role."""
+    db = SessionLocal()
+    try:
+        if isinstance(user_or_id, User):
+            user_obj = user_or_id
+        else:
+            user_obj = db.query(User).filter(User.id == user_or_id).first()
+        return bool(user_obj and user_obj.role == required_role)
+    finally:
+        db.close()

--- a/src/user.py
+++ b/src/user.py
@@ -15,6 +15,7 @@ class User(Base):
     name = Column(String, index=True)
     email = Column(String, unique=True, index=True)
     hashed_password = Column(String) # Storing hashed password
+    role = Column(String, nullable=False, default='parent')  # New role field
 
     # Relationship to Shifts (One-to-Many: User has many Shifts)
     shifts = relationship("Shift", back_populates="owner")
@@ -44,13 +45,14 @@ class User(Base):
     # For now, the focus is on the model definition.
 
     def __repr__(self):
-        return f"<User(id={self.id}, name='{self.name}', email='{self.email}')>"
+        return f"<User(id={self.id}, name='{self.name}', email='{self.email}', role='{self.role}')>"
 
     def to_dict(self, include_shifts=False, include_children=False, include_custodial_periods=False, include_shift_patterns=False): # Added include_shift_patterns
         data = {
             "id": self.id,
             "name": self.name,
-            "email": self.email
+            "email": self.email,
+            "role": self.role
             # Exclude hashed_password for security
         }
         if include_shifts and self.shifts: # Check if self.shifts is not None

--- a/templates/children.html
+++ b/templates/children.html
@@ -26,31 +26,32 @@
         <p>You have not added any children yet.</p>
     {% endif %}
 
-    <hr>
-
-    <h3>Add New Child</h3>
-    <form method="POST" action="{{ url_for('add_child_web') }}"> {# Changed action to avoid conflict with API #}
-        <div>
-            <label for="name">Child's Name:</label>
-            <input type="text" id="name" name="name" required>
-        </div>
-        <div>
-            <label for="date_of_birth">Date of Birth:</label>
-            <input type="date" id="date_of_birth" name="date_of_birth" required>
-        </div>
-        <div>
-            <label for="school_info">School Information (Optional):</label>
-            <input type="text" id="school_info" name="school_info">
-        </div>
-        {# Removing custody_schedule_info from this basic form as ResidencyPeriods are the preferred way #}
-        {# If a simple text field for old custody_schedule_info is still desired:
-        <div>
-            <label for="custody_schedule_info">Custody Notes (Optional):</label>
-            <textarea id="custody_schedule_info" name="custody_schedule_info"></textarea>
-        </div>
-        #}
-        <div>
-            <input type="submit" value="Add Child">
-        </div>
-    </form>
+    {% if session.get('role') == 'parent' %}
+        <hr>
+        <h3>Add New Child</h3>
+        <form method="POST" action="{{ url_for('add_child_web') }}"> {# Changed action to avoid conflict with API #}
+            <div>
+                <label for="name">Child's Name:</label>
+                <input type="text" id="name" name="name" required>
+            </div>
+            <div>
+                <label for="date_of_birth">Date of Birth:</label>
+                <input type="date" id="date_of_birth" name="date_of_birth" required>
+            </div>
+            <div>
+                <label for="school_info">School Information (Optional):</label>
+                <input type="text" id="school_info" name="school_info">
+            </div>
+            {# Removing custody_schedule_info from this basic form as ResidencyPeriods are the preferred way #}
+            {# If a simple text field for old custody_schedule_info is still desired:
+            <div>
+                <label for="custody_schedule_info">Custody Notes (Optional):</label>
+                <textarea id="custody_schedule_info" name="custody_schedule_info"></textarea>
+            </div>
+            #}
+            <div>
+                <input type="submit" value="Add Child">
+            </div>
+        </form>
+    {% endif %}
 {% endblock %}

--- a/templates/events.html
+++ b/templates/events.html
@@ -37,38 +37,40 @@
         <p>You have no events scheduled.</p>
     {% endif %}
 
-    <hr>
+    {% if session.get('role') == 'parent' %}
+        <hr>
 
-    <h3>Add New Event</h3>
-    <form method="POST" action="{{ url_for('add_event_web') }}">
-        <div>
-            <label for="title">Event Title:</label>
-            <input type="text" id="title" name="title" required>
-        </div>
-        <div>
-            <label for="description">Description (Optional):</label>
-            <textarea id="description" name="description"></textarea>
-        </div>
-        <div>
-            <label for="start_time">Start Time:</label>
-            <input type="datetime-local" id="start_time" name="start_time" required>
-        </div>
-        <div>
-            <label for="end_time">End Time:</label>
-            <input type="datetime-local" id="end_time" name="end_time" required>
-        </div>
-        <div>
-            <label for="child_id">Link to Child (Optional):</label>
-            <select id="child_id" name="child_id">
-                <option value="">-- None --</option>
-                {% for child in children %}
-                    <option value="{{ child.id }}">{{ child.name }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        {# Events created via this web interface are automatically linked to the current user #}
-        <div>
-            <input type="submit" value="Add Event">
-        </div>
-    </form>
+        <h3>Add New Event</h3>
+        <form method="POST" action="{{ url_for('add_event_web') }}">
+            <div>
+                <label for="title">Event Title:</label>
+                <input type="text" id="title" name="title" required>
+            </div>
+            <div>
+                <label for="description">Description (Optional):</label>
+                <textarea id="description" name="description"></textarea>
+            </div>
+            <div>
+                <label for="start_time">Start Time:</label>
+                <input type="datetime-local" id="start_time" name="start_time" required>
+            </div>
+            <div>
+                <label for="end_time">End Time:</label>
+                <input type="datetime-local" id="end_time" name="end_time" required>
+            </div>
+            <div>
+                <label for="child_id">Link to Child (Optional):</label>
+                <select id="child_id" name="child_id">
+                    <option value="">-- None --</option>
+                    {% for child in children %}
+                        <option value="{{ child.id }}">{{ child.name }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            {# Events created via this web interface are automatically linked to the current user #}
+            <div>
+                <input type="submit" value="Add Event">
+            </div>
+        </form>
+    {% endif %}
 {% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -31,8 +31,12 @@
             <ul>
                 <li><a href="{{ url_for('index') }}">Home</a></li>
                 {% if session.get('user_id') %}
+                    {% if session.get('role') == 'parent' %}
+                        <li><a href="{{ url_for('shifts_view') }}">Shifts</a></li>
+                        <li><a href="{{ url_for('children_view') }}">Children</a></li>
+                    {% endif %}
+                    <li><a href="{{ url_for('events_view') }}">Events</a></li>
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
-                    {# Add other authenticated links here, e.g., Profile, Dashboard #}
                 {% else %}
                     <li><a href="{{ url_for('login') }}">Login</a></li>
                     <li><a href="{{ url_for('register') }}">Register</a></li>

--- a/templates/register.html
+++ b/templates/register.html
@@ -18,6 +18,14 @@
             <input type="password" id="password" name="password" required>
         </div>
         <div>
+            <label for="role">Role:</label>
+            <select id="role" name="role">
+                <option value="parent">Parent</option>
+                <option value="teen">Teen</option>
+                <option value="child">Child</option>
+            </select>
+        </div>
+        <div>
             <input type="submit" value="Register">
         </div>
     </form>

--- a/templates/shifts.html
+++ b/templates/shifts.html
@@ -22,24 +22,25 @@
         <p>You have no shifts scheduled.</p>
     {% endif %}
 
-    <hr>
-
-    <h3>Add New Shift</h3>
-    <form method="POST" action="{{ url_for('add_shift') }}">
-        <div>
-            <label for="name">Shift Name:</label>
-            <input type="text" id="name" name="name" required>
-        </div>
-        <div>
-            <label for="start_time">Start Time:</label>
-            <input type="datetime-local" id="start_time" name="start_time" required>
-        </div>
-        <div>
-            <label for="end_time">End Time:</label>
-            <input type="datetime-local" id="end_time" name="end_time" required>
-        </div>
-        <div>
-            <input type="submit" value="Add Shift">
-        </div>
-    </form>
+    {% if session.get('role') == 'parent' %}
+        <hr>
+        <h3>Add New Shift</h3>
+        <form method="POST" action="{{ url_for('add_shift') }}">
+            <div>
+                <label for="name">Shift Name:</label>
+                <input type="text" id="name" name="name" required>
+            </div>
+            <div>
+                <label for="start_time">Start Time:</label>
+                <input type="datetime-local" id="start_time" name="start_time" required>
+            </div>
+            <div>
+                <label for="end_time">End Time:</label>
+                <input type="datetime-local" id="end_time" name="end_time" required>
+            </div>
+            <div>
+                <input type="submit" value="Add Shift">
+            </div>
+        </form>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `role` field to `User`
- expose `role` in `auth.register` and `login`
- enforce parent role for residency period API actions
- restrict CLI actions for non-parent roles
- show/hide navigation and forms in templates based on user role

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddfbb9c4832aa44b5a8f70aa6b36