### PR TITLE
Add document upload page

### DIFF
--- a/src/document.py
+++ b/src/document.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+from src.database import Base
+
+class Document(Base):
+    __tablename__ = 'documents'
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    child_id = Column(Integer, ForeignKey('children.id'), nullable=True)
+
+    user = relationship('User')
+    child = relationship('Child')
+
+    def to_dict(self, include_user=False, include_child=False):
+        data = {
+            'id': self.id,
+            'filename': self.filename,
+            'user_id': self.user_id,
+            'child_id': self.child_id
+        }
+        if include_user and self.user:
+            data['user'] = {'id': self.user.id, 'name': self.user.name}
+        if include_child and self.child:
+            data['child'] = {'id': self.child.id, 'name': self.child.name}
+        return data

--- a/templates/documents.html
+++ b/templates/documents.html
@@ -1,0 +1,43 @@
+{% extends "layout.html" %}
+
+{% block title %}Documents{% endblock %}
+
+{% block content %}
+    <h2>My Documents</h2>
+
+    {% if documents %}
+        <ul>
+        {% for doc in documents %}
+            <li>
+                {{ doc.filename }}
+                {% if doc.child %}- for {{ doc.child.name }}{% endif %}
+                <a href="{{ url_for('download_document', filename=doc.filename) }}">Download</a>
+            </li>
+        {% endfor %}
+        </ul>
+    {% else %}
+        <p>No documents uploaded.</p>
+    {% endif %}
+
+    <hr>
+
+    <h3>Upload Document</h3>
+    <form method="POST" enctype="multipart/form-data">
+        <div>
+            <label for="file">File:</label>
+            <input type="file" id="file" name="file" required>
+        </div>
+        <div>
+            <label for="child_id">Link to Child (Optional):</label>
+            <select id="child_id" name="child_id">
+                <option value="">-- None --</option>
+                {% for child in children %}
+                    <option value="{{ child.id }}">{{ child.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <input type="submit" value="Upload">
+        </div>
+    </form>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -31,6 +31,7 @@
             <ul>
                 <li><a href="{{ url_for('index') }}">Home</a></li>
                 {% if session.get('user_id') %}
+                    <li><a href="{{ url_for('documents_view') }}">Documents</a></li>
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
                     {# Add other authenticated links here, e.g., Profile, Dashboard #}
                 {% else %}


### PR DESCRIPTION
## Summary
- model documents with filename, user, and child
- enable file uploads and serving documents in `app.py`
- add `/documents` page and link it in the layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for Flask & SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6840ddfd2cc0832aadb4f2b196441b3b