### PR TITLE
Add API v1 with token auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ python app.py
 
 Visit `http://localhost:5000` in your browser.
 
+### API Usage
+
+Authenticate and obtain a token:
+
+```bash
+curl -X POST http://localhost:5000/api/v1/auth/login \
+     -H 'Content-Type: application/json' \
+     -d '{"email": "user@example.com", "password": "password"}'
+```
+
+Use the returned token with other endpoints:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+     http://localhost:5000/api/v1/events
+```
+
 ## Running Tests
 
 Install the requirements as above and run:

--- a/app.py
+++ b/app.py
@@ -1,10 +1,11 @@
-from flask import Flask, request, jsonify, render_template, redirect, url_for, session, flash
+from flask import Flask, request, jsonify, render_template, redirect, url_for, session, flash, Blueprint, g
 from sqlalchemy.exc import SQLAlchemyError
 import os # For secret key
 
 from src import auth, user, shift, child, event # Models
 from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
 from src.database import init_db, SessionLocal
+from src.token_manager import token_required, generate_token_for_user
 # Import residency_period model for init_db
 from src import residency_period
 
@@ -24,6 +25,19 @@ except Exception as e:
 app = Flask(__name__)
 app.secret_key = os.urandom(24) # Generate a random secret key for sessions
 
+# API blueprint
+api_bp = Blueprint('api_v1', __name__)
+
+# Simple OpenAPI spec endpoint
+@api_bp.route('/openapi.json')
+def openapi_spec():
+    spec = {
+        "openapi": "3.0.0",
+        "info": {"title": "Family Planner API", "version": "1.0"},
+        "paths": {}
+    }
+    return jsonify(spec)
+
 # Optional: A generic error handler for unhandled exceptions
 @app.errorhandler(Exception)
 def handle_generic_error(e):
@@ -33,7 +47,7 @@ def handle_generic_error(e):
     response.status_code = 500
     return response
 
-@app.route('/auth/register', methods=['POST'])
+@api_bp.route('/auth/register', methods=['POST'])
 def register_user():
     try:
         data = request.get_json()
@@ -68,7 +82,7 @@ def register_user():
         return jsonify(message="An unexpected error occurred during registration."), 500
 
 
-@app.route('/auth/login', methods=['POST'])
+@api_bp.route('/auth/login', methods=['POST'])
 def login_user():
     try:
         data = request.get_json()
@@ -82,8 +96,8 @@ def login_user():
         logged_in_user = auth.login(email=email, password=password)
 
         if logged_in_user:
-            # logged_in_user is an SQLAlchemy User model instance
-            return jsonify(message="Login successful", user_id=logged_in_user.id, name=logged_in_user.name, email=logged_in_user.email), 200
+            token = generate_token_for_user(logged_in_user.id)
+            return jsonify(message="Login successful", user_id=logged_in_user.id, name=logged_in_user.name, email=logged_in_user.email, token=token), 200
         else:
             # auth.login prints "Error: Email not found." or "Error: Incorrect password."
             return jsonify(message="Login failed: Invalid email or password."), 401 # Unauthorized
@@ -93,7 +107,8 @@ def login_user():
         return jsonify(message="An unexpected error occurred during login."), 500
 
 
-@app.route('/auth/logout', methods=['POST'])
+@api_bp.route('/auth/logout', methods=['POST'])
+@token_required
 def logout_user():
     # In a stateless API (common with tokens), logout is often handled client-side by deleting the token.
     # Server-side logout might involve invalidating a token if using a denylist.
@@ -105,7 +120,8 @@ def logout_user():
 
 # --- Child API Endpoints ---
 
-@app.route('/users/<int:user_id>/children', methods=['POST'])
+@api_bp.route('/users/<int:user_id>/children', methods=['POST'])
+@token_required
 def api_add_child(user_id):
     data = request.get_json()
     if not data or not all(k in data for k in ("name", "date_of_birth")):
@@ -131,20 +147,23 @@ def api_add_child(user_id):
         # child_manager.add_child prints errors
         return jsonify(message="Failed to add child. Invalid input or parent user not found."), 400
 
-@app.route('/children/<int:child_id>', methods=['GET'])
+@api_bp.route('/children/<int:child_id>', methods=['GET'])
+@token_required
 def api_get_child_details(child_id):
     child_obj = child_manager.get_child_details(child_id)
     if child_obj:
         return jsonify(child_obj.to_dict(include_parents=True)), 200
     return jsonify(message="Child not found"), 404
 
-@app.route('/users/<int:user_id>/children', methods=['GET'])
+@api_bp.route('/users/<int:user_id>/children', methods=['GET'])
+@token_required
 def api_get_user_children(user_id):
     # Optional: Validate user_id exists
     children_list = child_manager.get_user_children(user_id)
     return jsonify([c.to_dict(include_parents=False) for c in children_list]), 200 # include_parents=False to simplify
 
-@app.route('/children/<int:child_id>', methods=['PUT'])
+@api_bp.route('/children/<int:child_id>', methods=['PUT'])
+@token_required
 def api_update_child(child_id):
     data = request.get_json()
     if not data:
@@ -161,13 +180,15 @@ def api_update_child(child_id):
         return jsonify(updated_child_obj.to_dict(include_parents=True)), 200
     return jsonify(message="Child not found or update failed"), 404 # Or 400
 
-@app.route('/children/<int:child_id>', methods=['DELETE'])
+@api_bp.route('/children/<int:child_id>', methods=['DELETE'])
+@token_required
 def api_delete_child(child_id):
     if child_manager.remove_child(child_id):
         return jsonify(message="Child deleted successfully"), 200 # Or 204
     return jsonify(message="Child not found or delete failed"), 404
 
-@app.route('/children/<int:child_id>/parents', methods=['POST'])
+@api_bp.route('/children/<int:child_id>/parents', methods=['POST'])
+@token_required
 def api_add_parent_to_child(child_id):
     data = request.get_json()
     if not data or 'user_id' not in data:
@@ -199,7 +220,8 @@ def api_add_parent_to_child(child_id):
 
 # --- Event API Endpoints ---
 
-@app.route('/events', methods=['POST'])
+@api_bp.route('/events', methods=['POST'])
+@token_required
 def api_create_event():
     data = request.get_json()
     if not data or not all(k in data for k in ("title", "start_time", "end_time")):
@@ -219,26 +241,30 @@ def api_create_event():
         # event_manager.create_event prints errors
         return jsonify(message="Failed to create event. Invalid input or linked user/child not found."), 400
 
-@app.route('/events/<int:event_id>', methods=['GET'])
+@api_bp.route('/events/<int:event_id>', methods=['GET'])
+@token_required
 def api_get_event_details(event_id):
     event_obj = event_manager.get_event_details(event_id)
     if event_obj:
         return jsonify(event_obj.to_dict()), 200
     return jsonify(message="Event not found"), 404
 
-@app.route('/users/<int:user_id>/events', methods=['GET'])
+@api_bp.route('/users/<int:user_id>/events', methods=['GET'])
+@token_required
 def api_get_user_events(user_id):
     # Optional: Validate user_id exists
     events_list = event_manager.get_events_for_user(user_id)
     return jsonify([e.to_dict(include_user=False) for e in events_list]), 200 # Don't include user again
 
-@app.route('/children/<int:child_id>/events', methods=['GET'])
+@api_bp.route('/children/<int:child_id>/events', methods=['GET'])
+@token_required
 def api_get_child_events(child_id):
     # Optional: Validate child_id exists
     events_list = event_manager.get_events_for_child(child_id)
     return jsonify([e.to_dict(include_child=False) for e in events_list]), 200 # Don't include child again
 
-@app.route('/events/<int:event_id>', methods=['PUT'])
+@api_bp.route('/events/<int:event_id>', methods=['PUT'])
+@token_required
 def api_update_event(event_id):
     data = request.get_json()
     if not data:
@@ -263,7 +289,8 @@ def api_update_event(event_id):
         return jsonify(updated_event_obj.to_dict()), 200
     return jsonify(message="Event not found or update failed"), 404 # Or 400
 
-@app.route('/events/<int:event_id>', methods=['DELETE'])
+@api_bp.route('/events/<int:event_id>', methods=['DELETE'])
+@token_required
 def api_delete_event(event_id):
     if event_manager.delete_event(event_id):
         return jsonify(message="Event deleted successfully"), 200 # Or 204
@@ -272,7 +299,8 @@ def api_delete_event(event_id):
 
 # --- Shift Pattern API Endpoints ---
 
-@app.route('/shift-patterns', methods=['POST'])
+@api_bp.route('/shift-patterns', methods=['POST'])
+@token_required
 def api_create_global_shift_pattern():
     data = request.get_json()
     if not data or not all(k in data for k in ("name", "pattern_type", "definition")):
@@ -289,7 +317,8 @@ def api_create_global_shift_pattern():
         return jsonify(pattern.to_dict()), 201
     return jsonify(message="Failed to create global shift pattern"), 400
 
-@app.route('/users/<int:user_id>/shift-patterns', methods=['POST'])
+@api_bp.route('/users/<int:user_id>/shift-patterns', methods=['POST'])
+@token_required
 def api_create_user_shift_pattern(user_id):
     data = request.get_json()
     if not data or not all(k in data for k in ("name", "pattern_type", "definition")):
@@ -313,19 +342,22 @@ def api_create_user_shift_pattern(user_id):
         return jsonify(pattern.to_dict()), 201
     return jsonify(message="Failed to create user-specific shift pattern"), 400
 
-@app.route('/shift-patterns/<int:pattern_id>', methods=['GET'])
+@api_bp.route('/shift-patterns/<int:pattern_id>', methods=['GET'])
+@token_required
 def api_get_shift_pattern(pattern_id):
     pattern = shift_pattern_manager.get_shift_pattern(pattern_id)
     if pattern:
         return jsonify(pattern.to_dict()), 200
     return jsonify(message="Shift pattern not found"), 404
 
-@app.route('/shift-patterns', methods=['GET'])
+@api_bp.route('/shift-patterns', methods=['GET'])
+@token_required
 def api_get_global_shift_patterns():
     patterns = shift_pattern_manager.get_global_shift_patterns()
     return jsonify([p.to_dict() for p in patterns]), 200
 
-@app.route('/users/<int:user_id>/shift-patterns', methods=['GET'])
+@api_bp.route('/users/<int:user_id>/shift-patterns', methods=['GET'])
+@token_required
 def api_get_user_shift_patterns(user_id):
     # Optional: Validate user_id exists
     db = SessionLocal()
@@ -337,7 +369,8 @@ def api_get_user_shift_patterns(user_id):
     patterns = shift_pattern_manager.get_shift_patterns_for_user(user_id)
     return jsonify([p.to_dict() for p in patterns]), 200
 
-@app.route('/shift-patterns/<int:pattern_id>', methods=['PUT'])
+@api_bp.route('/shift-patterns/<int:pattern_id>', methods=['PUT'])
+@token_required
 def api_update_shift_pattern(pattern_id):
     data = request.get_json()
     if not data:
@@ -367,7 +400,8 @@ def api_update_shift_pattern(pattern_id):
         return jsonify(updated_pattern.to_dict()), 200
     return jsonify(message="Shift pattern not found or update failed"), 404 # Or 400
 
-@app.route('/shift-patterns/<int:pattern_id>', methods=['DELETE'])
+@api_bp.route('/shift-patterns/<int:pattern_id>', methods=['DELETE'])
+@token_required
 def api_delete_shift_pattern(pattern_id):
     # Similar ownership/admin check as in PUT would be needed here.
     # pattern_to_delete = shift_pattern_manager.get_shift_pattern(pattern_id)
@@ -381,7 +415,8 @@ def api_delete_shift_pattern(pattern_id):
         return jsonify(message="Shift pattern deleted successfully"), 200 # Or 204
     return jsonify(message="Shift pattern not found or delete failed"), 404
 
-@app.route('/users/<int:user_id>/shift-patterns/<int:pattern_id>/generate-shifts', methods=['POST'])
+@api_bp.route('/users/<int:user_id>/shift-patterns/<int:pattern_id>/generate-shifts', methods=['POST'])
+@token_required
 def api_generate_shifts_from_pattern(user_id, pattern_id):
     data = request.get_json()
     if not data or not all(k in data for k in ("start_date", "end_date")):
@@ -668,7 +703,8 @@ def add_child_web():
 
 
 # The previous residency period POST route:
-@app.route('/children/<int:child_id>/residency-periods', methods=['POST'])
+@api_bp.route('/children/<int:child_id>/residency-periods', methods=['POST'])
+@token_required
 def api_add_residency_period(child_id):
     data = request.get_json()
     if not data or not all(k in data for k in ("parent_id", "start_datetime", "end_datetime")):
@@ -702,7 +738,8 @@ def api_add_residency_period(child_id):
     finally:
         db.close()
 
-@app.route('/children/<int:child_id>/residency-periods', methods=['GET'])
+@api_bp.route('/children/<int:child_id>/residency-periods', methods=['GET'])
+@token_required
 def api_get_residency_periods_for_child(child_id):
     start_date_filter = request.args.get('start_date') # YYYY-MM-DD
     end_date_filter = request.args.get('end_date')     # YYYY-MM-DD
@@ -727,7 +764,8 @@ def api_get_residency_periods_for_child(child_id):
     finally:
         db.close()
 
-@app.route('/residency-periods/<int:period_id>', methods=['GET'])
+@api_bp.route('/residency-periods/<int:period_id>', methods=['GET'])
+@token_required
 def api_get_residency_period_details(period_id):
     db = SessionLocal()
     try:
@@ -738,7 +776,8 @@ def api_get_residency_period_details(period_id):
     finally:
         db.close()
 
-@app.route('/residency-periods/<int:period_id>', methods=['PUT'])
+@api_bp.route('/residency-periods/<int:period_id>', methods=['PUT'])
+@token_required
 def api_update_residency_period(period_id):
     data = request.get_json()
     if not data:
@@ -771,7 +810,8 @@ def api_update_residency_period(period_id):
     finally:
         db.close()
 
-@app.route('/residency-periods/<int:period_id>', methods=['DELETE'])
+@api_bp.route('/residency-periods/<int:period_id>', methods=['DELETE'])
+@token_required
 def api_delete_residency_period(period_id):
     db = SessionLocal()
     try:
@@ -791,7 +831,8 @@ def api_delete_residency_period(period_id):
     finally:
         db.close()
 
-@app.route('/children/<int:child_id>/residency', methods=['GET'])
+@api_bp.route('/children/<int:child_id>/residency', methods=['GET'])
+@token_required
 def api_get_child_residency_on_date(child_id):
     date_param = request.args.get('date')
     if not date_param:
@@ -825,7 +866,8 @@ def api_get_child_residency_on_date(child_id):
         return jsonify(message="An unexpected error occurred."), 500
     finally:
         db.close()
-
+# Register API blueprint
+app.register_blueprint(api_bp, url_prefix="/api/v1")
 
 if __name__ == '__main__':
     # Note: For development, app.run(debug=True) is fine.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 SQLAlchemy
 pytest
+flask-restx

--- a/src/api_token.py
+++ b/src/api_token.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from src.database import Base
+
+class APIToken(Base):
+    __tablename__ = 'api_tokens'
+
+    id = Column(Integer, primary_key=True, index=True)
+    token = Column(String, unique=True, index=True, nullable=False)
+    user_id = Column(Integer, ForeignKey('users.id'), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship('User')
+
+    def __repr__(self):
+        return f"<APIToken id={self.id} user_id={self.user_id}>"

--- a/src/token_manager.py
+++ b/src/token_manager.py
@@ -1,0 +1,50 @@
+import secrets
+from functools import wraps
+from flask import request, jsonify, g
+from sqlalchemy.exc import SQLAlchemyError
+from src.database import SessionLocal
+from src.api_token import APIToken
+from src.user import User
+
+
+def generate_token_for_user(user_id: int):
+    db = SessionLocal()
+    try:
+        token_value = secrets.token_hex(16)
+        token = APIToken(token=token_value, user_id=user_id)
+        db.add(token)
+        db.commit()
+        db.refresh(token)
+        return token.token
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error generating token: {e}")
+        return None
+    finally:
+        db.close()
+
+
+def get_user_by_token(token_value: str):
+    db = SessionLocal()
+    try:
+        token = db.query(APIToken).filter(APIToken.token == token_value).first()
+        if token:
+            return db.query(User).get(token.user_id)
+        return None
+    finally:
+        db.close()
+
+
+def token_required(f):
+    @wraps(f)
+    def decorated(*args, **kwargs):
+        auth = request.headers.get('Authorization')
+        if not auth or not auth.startswith('Bearer '):
+            return jsonify(message='Authorization token required'), 401
+        token_value = auth.split(' ')[1]
+        user = get_user_by_token(token_value)
+        if not user:
+            return jsonify(message='Invalid token'), 401
+        g.current_user = user
+        return f(*args, **kwargs)
+    return decorated

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -33,7 +33,8 @@ class TestAuthAPI(unittest.TestCase):
         # Ensure all models are imported so Base knows about them.
         # This should ideally be handled by having a central models import, e.g., in src/__init__.py
         # or by importing them explicitly here.
-        from src import user, shift, child, event, shift_pattern, residency_period # Import all models
+        from src import user, shift, child, event, shift_pattern, residency_period, api_token
+        # Import all models including tokens
         create_tables()
 
     @classmethod
@@ -60,7 +61,7 @@ class TestAuthAPI(unittest.TestCase):
         self.db.close()
 
     def _register_user_api(self, name="Test User", email="test@example.com", password="password123"):
-        return self.client.post('/auth/register', json={
+        return self.client.post('/api/v1/auth/register', json={
             "name": name,
             "email": email,
             "password": password
@@ -81,12 +82,12 @@ class TestAuthAPI(unittest.TestCase):
         self.assertEqual(user_in_db.id, data['user_id'])
 
     def test_register_missing_fields(self):
-        response = self.client.post('/auth/register', json={"name": "Test"})
+        response = self.client.post('/api/v1/auth/register', json={"name": "Test"})
         self.assertEqual(response.status_code, 400)
         data = response.get_json()
         self.assertIn("Missing", data['message'])
 
-        response_missing_email = self.client.post('/auth/register', json={
+        response_missing_email = self.client.post('/api/v1/auth/register', json={
             "name": "Another User", "password": "password123"
         })
         self.assertEqual(response_missing_email.status_code, 400)
@@ -104,7 +105,7 @@ class TestAuthAPI(unittest.TestCase):
         self.assertEqual(reg_response.status_code, 201)
 
         # Attempt login
-        response = self.client.post('/auth/login', json={
+        response = self.client.post('/api/v1/auth/login', json={
             "email": "login_test@example.com",
             "password": "password123"
         })
@@ -117,7 +118,7 @@ class TestAuthAPI(unittest.TestCase):
     def test_login_wrong_password(self):
         self._register_user_api(email="wrongpass@example.com", password="correctpassword")
 
-        response = self.client.post('/auth/login', json={
+        response = self.client.post('/api/v1/auth/login', json={
             "email": "wrongpass@example.com",
             "password": "incorrectpassword"
         })
@@ -126,7 +127,7 @@ class TestAuthAPI(unittest.TestCase):
         self.assertEqual(data['message'], "Login failed: Invalid email or password.")
 
     def test_login_user_not_found(self):
-        response = self.client.post('/auth/login', json={
+        response = self.client.post('/api/v1/auth/login', json={
             "email": "nosuchuser@example.com",
             "password": "password123"
         })
@@ -137,7 +138,7 @@ class TestAuthAPI(unittest.TestCase):
 
     def test_logout_success(self):
         # Logout is stateless for the API, just returns a message
-        response = self.client.post('/auth/logout')
+        response = self.client.post('/api/v1/auth/logout')
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(data['message'], "Logout successful")

--- a/tests/test_api_children_residency.py
+++ b/tests/test_api_children_residency.py
@@ -55,6 +55,8 @@ class TestAPIChildrenResidency(unittest.TestCase):
         # Default users for tests
         self.user1 = self._create_user_directly(name="User One", email="user1@example.com", password="password1")
         self.user2 = self._create_user_directly(name="User Two", email="user2@example.com", password="password2")
+        from src.token_manager import generate_token_for_user
+        self.token1 = generate_token_for_user(self.user1.id)
 
 
     def tearDown(self):
@@ -74,12 +76,15 @@ class TestAPIChildrenResidency(unittest.TestCase):
         self.db.refresh(user)
         return user
 
+    def _auth_headers(self):
+        return {"Authorization": f"Bearer {self.token1}"}
+
     def _create_child_for_user_api(self, user_id, child_name="Test Child", dob="2020-01-01"):
-        response = self.client.post(f'/users/{user_id}/children', json={
+        response = self.client.post(f'/api/v1/users/{user_id}/children', json={
             "name": child_name,
             "date_of_birth": dob,
             "school_info": "Test School"
-        })
+        }, headers=self._auth_headers())
         self.assertEqual(response.status_code, 201, f"Failed to create child via API: {response.get_data(as_text=True)}")
         return response.get_json()
 
@@ -101,14 +106,14 @@ class TestAPIChildrenResidency(unittest.TestCase):
         child_data = self._create_child_for_user_api(self.user1.id, "Daisy")
         child_id = child_data['id']
 
-        response = self.client.get(f'/children/{child_id}')
+        response = self.client.get(f'/api/v1/children/{child_id}', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(data['name'], "Daisy")
         self.assertEqual(data['id'], child_id)
 
     def test_get_child_details_not_found(self):
-        response = self.client.get('/children/99999')
+        response = self.client.get('/api/v1/children/99999', headers=self._auth_headers())
         self.assertEqual(response.status_code, 404)
 
     def test_get_user_children_success(self):
@@ -117,7 +122,7 @@ class TestAPIChildrenResidency(unittest.TestCase):
         # Create a child for another user to ensure filtering
         self._create_child_for_user_api(self.user2.id, "Child C")
 
-        response = self.client.get(f'/users/{self.user1.id}/children')
+        response = self.client.get(f'/api/v1/users/{self.user1.id}/children', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(len(data), 2)
@@ -130,7 +135,7 @@ class TestAPIChildrenResidency(unittest.TestCase):
         child_id = child_data['id']
 
         update_payload = {"name": "Updated Name", "school_info": "New School"}
-        response = self.client.put(f'/children/{child_id}', json=update_payload)
+        response = self.client.put(f'/api/v1/children/{child_id}', json=update_payload, headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(data['name'], "Updated Name")
@@ -152,7 +157,7 @@ class TestAPIChildrenResidency(unittest.TestCase):
         self.db.commit()
         res_period_id = res_period.id
 
-        response = self.client.delete(f'/children/{child_id}')
+        response = self.client.delete(f'/api/v1/children/{child_id}', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
 
         self.assertIsNone(self.db.query(Child).get(child_id))
@@ -162,7 +167,7 @@ class TestAPIChildrenResidency(unittest.TestCase):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
 
-        response = self.client.post(f'/children/{child_id}/parents', json={"user_id": self.user2.id})
+        response = self.client.post(f'/api/v1/children/{child_id}/parents', json={"user_id": self.user2.id}, headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
 
         # Verify in DB
@@ -172,13 +177,13 @@ class TestAPIChildrenResidency(unittest.TestCase):
         self.assertIn(self.user2.id, parent_ids)
 
     def test_add_parent_to_child_child_not_found(self):
-        response = self.client.post('/children/99999/parents', json={"user_id": self.user1.id})
+        response = self.client.post('/api/v1/children/99999/parents', json={"user_id": self.user1.id}, headers=self._auth_headers())
         self.assertEqual(response.status_code, 404) # API should check child existence
 
     def test_add_parent_to_child_new_parent_not_found(self):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
-        response = self.client.post(f'/children/{child_id}/parents', json={"user_id": 99999})
+        response = self.client.post(f'/api/v1/children/{child_id}/parents', json={"user_id": 99999}, headers=self._auth_headers())
         self.assertEqual(response.status_code, 404) # API should check new parent existence
 
 
@@ -193,7 +198,7 @@ class TestAPIChildrenResidency(unittest.TestCase):
             "end_datetime": "2024-01-05 18:00:00",
             "notes": "Week with User One"
         }
-        response = self.client.post(f'/children/{child_id}/residency-periods', json=payload)
+        response = self.client.post(f'/api/v1/children/{child_id}/residency-periods', json=payload, headers=self._auth_headers())
         self.assertEqual(response.status_code, 201)
         data = response.get_json()
         self.assertEqual(data['child_id'], child_id)
@@ -211,10 +216,10 @@ class TestAPIChildrenResidency(unittest.TestCase):
         # Add some periods
         rp1_payload = {"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00"}
         rp2_payload = {"parent_id": self.user2.id, "start_datetime": "2024-01-05 18:00", "end_datetime": "2024-01-10 10:00"}
-        self.client.post(f'/children/{child_id}/residency-periods', json=rp1_payload)
-        self.client.post(f'/children/{child_id}/residency-periods', json=rp2_payload)
+        self.client.post(f'/api/v1/children/{child_id}/residency-periods', json=rp1_payload, headers=self._auth_headers())
+        self.client.post(f'/api/v1/children/{child_id}/residency-periods', json=rp2_payload, headers=self._auth_headers())
 
-        response = self.client.get(f'/children/{child_id}/residency-periods')
+        response = self.client.get(f'/api/v1/children/{child_id}/residency-periods', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(len(data), 2)
@@ -222,11 +227,11 @@ class TestAPIChildrenResidency(unittest.TestCase):
     def test_get_residency_periods_for_child_with_date_filters(self):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
-        self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00"})
-        self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user2.id, "start_datetime": "2024-01-05 18:00", "end_datetime": "2024-01-10 10:00"})
-        self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-10 10:00", "end_datetime": "2024-01-15 18:00"})
+        self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00"}, headers=self._auth_headers())
+        self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user2.id, "start_datetime": "2024-01-05 18:00", "end_datetime": "2024-01-10 10:00"}, headers=self._auth_headers())
+        self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-10 10:00", "end_datetime": "2024-01-15 18:00"}, headers=self._auth_headers())
 
-        response = self.client.get(f'/children/{child_id}/residency-periods?start_date=2024-01-04&end_date=2024-01-11')
+        response = self.client.get(f'/api/v1/children/{child_id}/residency-periods?start_date=2024-01-04&end_date=2024-01-11', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         # Expecting 3 periods: first one overlaps start, second is within, third overlaps end
@@ -235,27 +240,27 @@ class TestAPIChildrenResidency(unittest.TestCase):
     def test_get_residency_period_details_success(self):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
-        rp_res = self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00", "notes": "Test notes"})
+        rp_res = self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00", "notes": "Test notes"}, headers=self._auth_headers())
         period_id = rp_res.get_json()['id']
 
-        response = self.client.get(f'/residency-periods/{period_id}')
+        response = self.client.get(f'/api/v1/residency-periods/{period_id}', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(data['id'], period_id)
         self.assertEqual(data['notes'], "Test notes")
 
     def test_get_residency_period_details_not_found(self):
-        response = self.client.get('/residency-periods/99999')
+        response = self.client.get('/api/v1/residency-periods/99999', headers=self._auth_headers())
         self.assertEqual(response.status_code, 404)
 
     def test_update_residency_period_success(self):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
-        rp_res = self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00"})
+        rp_res = self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00"}, headers=self._auth_headers())
         period_id = rp_res.get_json()['id']
 
         update_payload = {"notes": "Updated notes", "parent_id": self.user2.id}
-        response = self.client.put(f'/residency-periods/{period_id}', json=update_payload)
+        response = self.client.put(f'/api/v1/residency-periods/{period_id}', json=update_payload, headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(data['notes'], "Updated notes")
@@ -268,19 +273,19 @@ class TestAPIChildrenResidency(unittest.TestCase):
     def test_delete_residency_period_success(self):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
-        rp_res = self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00"})
+        rp_res = self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-01-01 10:00", "end_datetime": "2024-01-05 18:00"}, headers=self._auth_headers())
         period_id = rp_res.get_json()['id']
 
-        response = self.client.delete(f'/residency-periods/{period_id}')
+        response = self.client.delete(f'/api/v1/residency-periods/{period_id}', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(self.db.query(ResidencyPeriod).get(period_id))
 
     def test_get_child_residency_on_date_success(self):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
-        self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-03-01 10:00", "end_datetime": "2024-03-05 18:00"})
+        self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-03-01 10:00", "end_datetime": "2024-03-05 18:00"}, headers=self._auth_headers())
 
-        response = self.client.get(f'/children/{child_id}/residency?date=2024-03-03')
+        response = self.client.get(f'/api/v1/children/{child_id}/residency?date=2024-03-03', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(len(data), 1)
@@ -290,9 +295,9 @@ class TestAPIChildrenResidency(unittest.TestCase):
     def test_get_child_residency_on_date_no_period(self):
         child_data = self._create_child_for_user_api(self.user1.id)
         child_id = child_data['id']
-        self.client.post(f'/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-03-01 10:00", "end_datetime": "2024-03-05 18:00"})
+        self.client.post(f'/api/v1/children/{child_id}/residency-periods', json={"parent_id": self.user1.id, "start_datetime": "2024-03-01 10:00", "end_datetime": "2024-03-05 18:00"}, headers=self._auth_headers())
 
-        response = self.client.get(f'/children/{child_id}/residency?date=2024-03-10')
+        response = self.client.get(f'/api/v1/children/{child_id}/residency?date=2024-03-10', headers=self._auth_headers())
         self.assertEqual(response.status_code, 404) # Expect 404 if no period found
 
 if __name__ == '__main__':

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -18,6 +18,7 @@ from src.database import initialize_database_for_application, create_tables, dro
 from src.user import User
 from src.child import Child
 from src.event import Event
+from src.token_manager import generate_token_for_user
 
 class TestAPIEvents(unittest.TestCase):
 
@@ -50,6 +51,7 @@ class TestAPIEvents(unittest.TestCase):
         self.user1 = self._create_user_directly(name="Event User One", email="eventuser1@example.com", password="password1")
         self.user2 = self._create_user_directly(name="Event User Two", email="eventuser2@example.com", password="password2")
         self.child1_user1 = self._create_child_for_user_db(user_id=self.user1.id, child_name="Event Child One of User1")
+        self.token1 = generate_token_for_user(self.user1.id)
 
     def tearDown(self):
         self.db.query(Event).delete()
@@ -80,6 +82,9 @@ class TestAPIEvents(unittest.TestCase):
         self.db.refresh(child_obj)
         return child_obj
 
+    def _auth_headers(self):
+        return {"Authorization": f"Bearer {self.token1}"}
+
     def _create_event_api(self, title, start_time_str, end_time_str, user_id=None, child_id=None, description=None):
         payload = {
             "title": title,
@@ -93,7 +98,7 @@ class TestAPIEvents(unittest.TestCase):
         if child_id:
             payload["child_id"] = child_id
 
-        return self.client.post('/events', json=payload)
+        return self.client.post('/api/v1/events', json=payload, headers=self._auth_headers())
 
     # --- Test Methods for Events ---
     def test_create_event_for_user_success(self):
@@ -149,14 +154,14 @@ class TestAPIEvents(unittest.TestCase):
         event_res = self._create_event_api("Get Details Event", "2024-01-01 10:00", "2024-01-01 11:00", user_id=self.user1.id)
         event_id = event_res.get_json()['id']
 
-        response = self.client.get(f'/events/{event_id}')
+        response = self.client.get(f'/api/v1/events/{event_id}', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(data['title'], "Get Details Event")
         self.assertEqual(data['id'], event_id)
 
     def test_get_event_details_not_found(self):
-        response = self.client.get('/events/99999')
+        response = self.client.get('/api/v1/events/99999', headers=self._auth_headers())
         self.assertEqual(response.status_code, 404)
 
     def test_get_events_for_user_success(self):
@@ -164,7 +169,7 @@ class TestAPIEvents(unittest.TestCase):
         self._create_event_api("User1 Event B", "2024-01-02 10:00", "2024-01-02 11:00", user_id=self.user1.id)
         self._create_event_api("User2 Event C", "2024-01-03 10:00", "2024-01-03 11:00", user_id=self.user2.id)
 
-        response = self.client.get(f'/users/{self.user1.id}/events')
+        response = self.client.get(f'/api/v1/users/{self.user1.id}/events', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(len(data), 2)
@@ -178,7 +183,7 @@ class TestAPIEvents(unittest.TestCase):
         self._create_event_api("Child1 Event Y", "2024-01-02 10:00", "2024-01-02 11:00", child_id=self.child1_user1.id)
         self._create_event_api("Child2 Event Z", "2024-01-03 10:00", "2024-01-03 11:00", child_id=child2_user1.id)
 
-        response = self.client.get(f'/children/{self.child1_user1.id}/events')
+        response = self.client.get(f'/api/v1/children/{self.child1_user1.id}/events', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(len(data), 2)
@@ -191,7 +196,7 @@ class TestAPIEvents(unittest.TestCase):
         event_id = event_res.get_json()['id']
 
         update_payload = {"title": "New Updated Title", "description": "Updated Desc"}
-        response = self.client.put(f'/events/{event_id}', json=update_payload)
+        response = self.client.put(f'/api/v1/events/{event_id}', json=update_payload, headers=self._auth_headers())
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertEqual(data['title'], "New Updated Title")
@@ -204,7 +209,7 @@ class TestAPIEvents(unittest.TestCase):
         event_res = self._create_event_api("To Delete Event", "2024-01-01 10:00", "2024-01-01 11:00")
         event_id = event_res.get_json()['id']
 
-        response = self.client.delete(f'/events/{event_id}')
+        response = self.client.delete(f'/api/v1/events/{event_id}', headers=self._auth_headers())
         self.assertEqual(response.status_code, 200) # API returns 200
         self.assertIsNone(self.db.query(Event).get(event_id))
 


### PR DESCRIPTION
## Summary
- version API under `/api/v1`
- add token-based auth and token table
- expose a simple OpenAPI spec
- update tests for new paths and auth
- document token usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840ddfe6480832a86baa7831371ff90