### PR TITLE
Add basic 2FA support

### DIFF
--- a/app.py
+++ b/app.py
@@ -77,9 +77,10 @@ def login_user():
 
         email = data.get('email')
         password = data.get('password')
+        otp = data.get('otp')
 
         # auth.login now uses SQLAlchemy
-        logged_in_user = auth.login(email=email, password=password)
+        logged_in_user = auth.login(email=email, password=password, otp=otp)
 
         if logged_in_user:
             # logged_in_user is an SQLAlchemy User model instance
@@ -101,6 +102,28 @@ def logout_user():
     # auth.logout() itself just prints a message.
     auth.logout()
     return jsonify(message="Logout successful"), 200
+
+
+@app.route('/auth/otp/generate', methods=['POST'])
+def generate_otp_route():
+    data = request.get_json()
+    if not data or 'user_id' not in data:
+        return jsonify(message="Missing user_id"), 400
+    otp = auth.generate_otp(data['user_id'])
+    if otp is None:
+        return jsonify(message="OTP generation failed"), 400
+    return jsonify(otp=otp), 200
+
+
+@app.route('/auth/otp/verify', methods=['POST'])
+def verify_otp_route():
+    data = request.get_json()
+    if not data or not all(k in data for k in ('user_id', 'otp')):
+        return jsonify(message="Missing user_id or otp"), 400
+    if auth.verify_otp(data['user_id'], data['otp']):
+        return jsonify(message="OTP verified"), 200
+    else:
+        return jsonify(message="Invalid OTP"), 400
 
 
 # --- Child API Endpoints ---

--- a/main.py
+++ b/main.py
@@ -43,7 +43,8 @@ def handle_login():
     global current_user
     email = input("Enter email: ")
     password = input("Enter password: ")
-    user = auth.login(email, password)
+    otp = input("Enter OTP (leave blank if not enabled): ") or None
+    user = auth.login(email, password, otp)
     if user:
         current_user = user # Store the User object
         print(f"User '{user.name}' logged in successfully.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 SQLAlchemy
 pytest
+pyotp

--- a/src/user.py
+++ b/src/user.py
@@ -15,6 +15,7 @@ class User(Base):
     name = Column(String, index=True)
     email = Column(String, unique=True, index=True)
     hashed_password = Column(String) # Storing hashed password
+    two_factor_secret = Column(String, nullable=True)
 
     # Relationship to Shifts (One-to-Many: User has many Shifts)
     shifts = relationship("Shift", back_populates="owner")

--- a/templates/login.html
+++ b/templates/login.html
@@ -14,6 +14,10 @@
             <input type="password" id="password" name="password" required>
         </div>
         <div>
+            <label for="otp">OTP:</label>
+            <input type="text" id="otp" name="otp">
+        </div>
+        <div>
             <input type="submit" value="Login">
         </div>
     </form>

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -125,6 +125,15 @@ class TestAuthAPI(unittest.TestCase):
         data = response.get_json()
         self.assertEqual(data['message'], "Login failed: Invalid email or password.")
 
+    def test_otp_endpoints(self):
+        reg_response = self._register_user_api(email="otp_api@example.com")
+        user_id = reg_response.get_json()['user_id']
+        gen_resp = self.client.post('/auth/otp/generate', json={"user_id": user_id})
+        self.assertEqual(gen_resp.status_code, 200)
+        otp = gen_resp.get_json()['otp']
+        verify_resp = self.client.post('/auth/otp/verify', json={"user_id": user_id, "otp": otp})
+        self.assertEqual(verify_resp.status_code, 200)
+
     def test_login_user_not_found(self):
         response = self.client.post('/auth/login', json={
             "email": "nosuchuser@example.com",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -85,6 +85,21 @@ class TestAuth(unittest.TestCase):
         logged_in_user = auth.login("test@example.com", "wrongpassword")
         self.assertIsNone(logged_in_user)
 
+    def test_generate_and_verify_otp(self):
+        user = auth.register("OTP User", "otp@example.com", "password123")
+        otp = auth.generate_otp(user.id)
+        self.assertIsNotNone(otp)
+        self.assertTrue(auth.verify_otp(user.id, otp))
+
+    def test_login_with_otp(self):
+        user = auth.register("OTP User2", "otp2@example.com", "password123")
+        otp = auth.generate_otp(user.id)
+        # Login without OTP should fail
+        self.assertIsNone(auth.login("otp2@example.com", "password123"))
+        # Login with OTP should succeed
+        logged_in = auth.login("otp2@example.com", "password123", otp)
+        self.assertIsNotNone(logged_in)
+
     def test_logout(self):
         # Logout is a simple print and pass in the current implementation.
         # Test that it executes without error.


### PR DESCRIPTION
## Summary
- add `pyotp` dependency
- store `two_factor_secret` for users
- generate and verify OTP codes
- prompt for OTP in CLI and login form
- expose OTP routes for the API
- add unit tests for OTP functionality

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840de010b88832ab22aaf4fb5d483d1