### PR TITLE
Add meal plan feature

### DIFF
--- a/src/meal_plan.py
+++ b/src/meal_plan.py
@@ -1,0 +1,149 @@
+from sqlalchemy import Column, Integer, String, Text, Date
+from sqlalchemy.exc import SQLAlchemyError
+from datetime import date
+import json
+
+from .database import Base, SessionLocal
+
+class Recipe(Base):
+    __tablename__ = "recipes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    ingredients = Column(Text)  # JSON encoded list
+    instructions = Column(Text, nullable=True)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "ingredients": json.loads(self.ingredients) if self.ingredients else [],
+            "instructions": self.instructions,
+        }
+
+class MealPlan(Base):
+    __tablename__ = "meal_plans"
+
+    id = Column(Integer, primary_key=True, index=True)
+    week_start = Column(Date, nullable=False)
+    recipe_ids = Column(Text)  # JSON encoded list of recipe ids
+
+    def to_dict(self, include_grocery=False):
+        data = {
+            "id": self.id,
+            "week_start": self.week_start.isoformat() if self.week_start else None,
+            "recipe_ids": json.loads(self.recipe_ids) if self.recipe_ids else [],
+        }
+        if include_grocery:
+            data["grocery_list"] = generate_grocery_list(self)
+        return data
+
+def create_recipe(name, ingredients, instructions=None):
+    db = SessionLocal()
+    try:
+        r = Recipe(name=name, ingredients=json.dumps(ingredients), instructions=instructions)
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+        return r
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error creating recipe: {e}")
+        return None
+    finally:
+        db.close()
+
+def get_recipe(recipe_id):
+    db = SessionLocal()
+    try:
+        return db.query(Recipe).get(recipe_id)
+    finally:
+        db.close()
+
+def update_recipe(recipe_id, name=None, ingredients=None, instructions=None):
+    db = SessionLocal()
+    try:
+        recipe = db.query(Recipe).get(recipe_id)
+        if not recipe:
+            return None
+        if name is not None:
+            recipe.name = name
+        if ingredients is not None:
+            recipe.ingredients = json.dumps(ingredients)
+        if instructions is not None:
+            recipe.instructions = instructions
+        db.commit()
+        db.refresh(recipe)
+        return recipe
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error updating recipe: {e}")
+        return None
+    finally:
+        db.close()
+
+def delete_recipe(recipe_id):
+    db = SessionLocal()
+    try:
+        recipe = db.query(Recipe).get(recipe_id)
+        if not recipe:
+            return False
+        db.delete(recipe)
+        db.commit()
+        return True
+    except SQLAlchemyError as e:
+        db.rollback()
+        print(f"Database error deleting recipe: {e}")
+        return False
+    finally:
+        db.close()
+
+def list_recipes():
+    db = SessionLocal()
+    try:
+        return db.query(Recipe).all()
+    finally:
+        db.close()
+
+def create_meal_plan(week_start_str, recipe_ids):
+    db = SessionLocal()
+    try:
+        week_start = date.fromisoformat(week_start_str)
+        plan = MealPlan(week_start=week_start, recipe_ids=json.dumps(recipe_ids))
+        db.add(plan)
+        db.commit()
+        db.refresh(plan)
+        return plan
+    except (SQLAlchemyError, ValueError) as e:
+        db.rollback()
+        print(f"Error creating meal plan: {e}")
+        return None
+    finally:
+        db.close()
+
+def get_meal_plan(plan_id):
+    db = SessionLocal()
+    try:
+        return db.query(MealPlan).get(plan_id)
+    finally:
+        db.close()
+
+def list_meal_plans():
+    db = SessionLocal()
+    try:
+        return db.query(MealPlan).all()
+    finally:
+        db.close()
+
+def generate_grocery_list(plan):
+    db = SessionLocal()
+    try:
+        ingredients = []
+        ids = json.loads(plan.recipe_ids) if plan.recipe_ids else []
+        for rid in ids:
+            recipe = db.query(Recipe).get(rid)
+            if recipe:
+                ingredients.extend(json.loads(recipe.ingredients) if recipe.ingredients else [])
+        return sorted(set(ingredients))
+    finally:
+        db.close()

--- a/tests/test_api_meal_plans.py
+++ b/tests/test_api_meal_plans.py
@@ -1,0 +1,76 @@
+import unittest
+import os
+import sys
+
+sys_path_updated = False
+if os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) not in sys.path:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    sys_path_updated = True
+
+os.environ["TEST_MODE_ENABLED"] = "1"
+
+from app import app
+from src.database import initialize_database_for_application, create_tables, drop_tables, SessionLocal
+from src import meal_plan
+
+class TestMealPlanAPI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        initialize_database_for_application()
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        app.config['SECRET_KEY'] = 'test_secret_key_meal'
+        from src import user, shift, child, event, shift_pattern, residency_period, meal_plan as mp
+        create_tables()
+
+    @classmethod
+    def tearDownClass(cls):
+        drop_tables()
+        if "TEST_MODE_ENABLED" in os.environ:
+            del os.environ["TEST_MODE_ENABLED"]
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.db = SessionLocal()
+        self.db.query(meal_plan.MealPlan).delete()
+        self.db.query(meal_plan.Recipe).delete()
+        self.db.commit()
+
+    def tearDown(self):
+        self.db.query(meal_plan.MealPlan).delete()
+        self.db.query(meal_plan.Recipe).delete()
+        self.db.commit()
+        self.db.close()
+
+    def test_recipe_crud(self):
+        resp = self.client.post('/recipes', json={"name": "Pancakes", "ingredients": ["flour", "milk"], "instructions": "Mix"})
+        self.assertEqual(resp.status_code, 201)
+        r_id = resp.get_json()['id']
+
+        resp = self.client.get(f'/recipes/{r_id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()['name'], "Pancakes")
+
+        resp = self.client.put(f'/recipes/{r_id}', json={"name": "Best Pancakes"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()['name'], "Best Pancakes")
+
+        resp = self.client.delete(f'/recipes/{r_id}')
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(self.db.query(meal_plan.Recipe).get(r_id))
+
+    def test_meal_plan_grocery_generation(self):
+        r1 = self.client.post('/recipes', json={"name": "Omelette", "ingredients": ["eggs", "milk"]}).get_json()
+        r2 = self.client.post('/recipes', json={"name": "Cake", "ingredients": ["milk", "flour"]}).get_json()
+        resp = self.client.post('/meal-plans', json={"week_start": "2024-08-05", "recipe_ids": [r1['id'], r2['id']]})
+        self.assertEqual(resp.status_code, 201)
+        data = resp.get_json()
+        self.assertEqual(set(data['grocery_list']), {"eggs", "milk", "flour"})
+        plan_id = data['id']
+
+        resp = self.client.get(f'/meal-plans/{plan_id}/groceries')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(set(resp.get_json()['grocery_list']), {"eggs", "milk", "flour"})
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- define `Recipe` and `MealPlan` models with helpers
- expose REST API endpoints for recipes and weekly meal plans
- allow grocery list generation from meal plans
- test recipe CRUD and grocery list generation

## Testing
- `pip install -q Flask SQLAlchemy pytest` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails to import flask and sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6840de0465f4832aaf820e6a3e332fbb