### PR TITLE
Add health dashboard and event categories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 SQLAlchemy
 pytest
+requests

--- a/src/event.py
+++ b/src/event.py
@@ -9,6 +9,7 @@ class Event(Base):
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String, index=True)
     description = Column(String, nullable=True)
+    category = Column(String, nullable=True)
     start_time = Column(DateTime) # Previous: start_time (str)
     end_time = Column(DateTime)   # Previous: end_time (str)
 
@@ -38,6 +39,7 @@ class Event(Base):
             "id": self.id,
             "title": self.title,
             "description": self.description,
+            "category": self.category,
             "start_time": self.start_time.isoformat() if self.start_time else None,
             "end_time": self.end_time.isoformat() if self.end_time else None,
             "user_id": self.user_id,

--- a/src/event_manager.py
+++ b/src/event_manager.py
@@ -22,7 +22,8 @@ def _parse_datetime(datetime_str: str):
         return None
 
 def create_event(title: str, description: str, start_time_str: str, end_time_str: str,
-                 linked_user_id: int = None, linked_child_id: int = None):
+                 linked_user_id: int = None, linked_child_id: int = None,
+                 category: str = None):
     db = SessionLocal()
     try:
         start_time_dt = _parse_datetime(start_time_str)
@@ -36,6 +37,7 @@ def create_event(title: str, description: str, start_time_str: str, end_time_str
         new_event = Event(
             title=title,
             description=description,
+            category=category,
             start_time=start_time_dt,
             end_time=end_time_dt,
             user_id=linked_user_id, # This is the FK field in Event model
@@ -90,6 +92,7 @@ def get_events_for_child(child_id: int):
 def update_event(event_id: int, title: str = None, description: str = None,
                  start_time_str: str = None, end_time_str: str = None,
                  linked_user_id: int = None, linked_child_id: int = None,
+                 category: str = None,
                  unlink_user: bool = False, unlink_child: bool = False): # Added unlink flags
     db = SessionLocal()
     try:
@@ -104,6 +107,9 @@ def update_event(event_id: int, title: str = None, description: str = None,
             updated = True
         if description is not None:
             event.description = description
+            updated = True
+        if category is not None:
+            event.category = category
             updated = True
         if start_time_str is not None:
             start_time_dt = _parse_datetime(start_time_str)

--- a/src/health_device.py
+++ b/src/health_device.py
@@ -1,0 +1,51 @@
+import os
+from datetime import date
+from typing import Optional, Dict, Any
+
+import requests
+
+
+class HealthDevice:
+    """Simple client for wearable device APIs."""
+
+    def __init__(self, base_url: str, token: str):
+        self.base_url = base_url.rstrip('/')
+        self.token = token
+
+    def _get(self, endpoint: str, params: Optional[Dict[str, Any]] = None):
+        url = f"{self.base_url}/{endpoint.lstrip('/')}"
+        headers = {"Authorization": f"Bearer {self.token}"}
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=5)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.RequestException as e:
+            print(f"HealthDevice API request failed: {e}")
+            return None
+
+    def fetch_steps(self, start: date, end: date):
+        params = {"start": start.isoformat(), "end": end.isoformat()}
+        return self._get("steps", params)
+
+    def fetch_sleep(self, start: date, end: date):
+        params = {"start": start.isoformat(), "end": end.isoformat()}
+        return self._get("sleep", params)
+
+
+def summarize_health(steps_data: Any, sleep_data: Any) -> Dict[str, Any]:
+    """Return basic totals from fetched data."""
+    summary = {"total_steps": 0, "total_sleep_hours": 0}
+    if steps_data and isinstance(steps_data, list):
+        summary["total_steps"] = sum(d.get("steps", 0) for d in steps_data)
+    if sleep_data and isinstance(sleep_data, list):
+        summary["total_sleep_hours"] = sum(d.get("hours", 0) for d in sleep_data)
+    return summary
+
+
+def device_from_env() -> Optional[HealthDevice]:
+    """Create HealthDevice from environment variables if available."""
+    base = os.environ.get("HEALTH_API_URL")
+    token = os.environ.get("HEALTH_API_TOKEN")
+    if not base or not token:
+        return None
+    return HealthDevice(base, token)

--- a/templates/events.html
+++ b/templates/events.html
@@ -11,6 +11,9 @@
                 <li>
                     <strong>{{ event.title }}</strong>
                     <p>{{ event.description if event.description else 'No description.' }}</p>
+                    {% if event.category %}
+                        <em>Category: {{ event.category }}</em><br>
+                    {% endif %}
                     <small>
                         From: {{ event.start_time.strftime('%Y-%m-%d %H:%M') if event.start_time else 'N/A' }} <br>
                         To: {{ event.end_time.strftime('%Y-%m-%d %H:%M') if event.end_time else 'N/A' }}
@@ -48,6 +51,10 @@
         <div>
             <label for="description">Description (Optional):</label>
             <textarea id="description" name="description"></textarea>
+        </div>
+        <div>
+            <label for="category">Category (Optional):</label>
+            <input type="text" id="category" name="category">
         </div>
         <div>
             <label for="start_time">Start Time:</label>

--- a/templates/health.html
+++ b/templates/health.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+
+{% block title %}Health Dashboard{% endblock %}
+
+{% block content %}
+    <h2>Health Dashboard</h2>
+    {% if summary %}
+        <p>Total Steps: {{ summary.total_steps }}</p>
+        <p>Total Sleep Hours: {{ summary.total_sleep_hours }}</p>
+    {% else %}
+        <p>No health data available.</p>
+    {% endif %}
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -32,6 +32,7 @@
                 <li><a href="{{ url_for('index') }}">Home</a></li>
                 {% if session.get('user_id') %}
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
+                    <li><a href="{{ url_for('health_dashboard') }}">Health</a></li>
                     {# Add other authenticated links here, e.g., Profile, Dashboard #}
                 {% else %}
                     <li><a href="{{ url_for('login') }}">Login</a></li>


### PR DESCRIPTION
## Summary
- allow events to be categorised
- add client for wearable APIs and create `/health` dashboard
- show category when listing events
- expose health dashboard link in navigation
- include `requests` in dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840de067370832a85337db070f60415