### PR TITLE
Add destination and travel info support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,9 @@
 from flask import Flask, request, jsonify, render_template, redirect, url_for, session, flash
 from sqlalchemy.exc import SQLAlchemyError
-import os # For secret key
+import os  # For secret key
+from datetime import datetime, timedelta
+
+from src import travel_info
 
 from src import auth, user, shift, child, event # Models
 from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
@@ -15,7 +18,6 @@ try:
     from src import user, shift, child, event # Models
     # Import residency_period model for init_db
     from src import residency_period
-    from datetime import datetime # For HTML form datetime-local conversion
     init_db()
 except Exception as e:
     print(f"Error initializing database during app startup: {e}")
@@ -210,8 +212,9 @@ def api_create_event():
         description=data.get('description'),
         start_time_str=data['start_time'],
         end_time_str=data['end_time'],
-        linked_user_id=data.get('user_id'), # Optional
-        linked_child_id=data.get('child_id') # Optional
+        linked_user_id=data.get('user_id'),  # Optional
+        linked_child_id=data.get('child_id'),  # Optional
+        destination=data.get('destination')
     )
     if new_event_obj:
         return jsonify(new_event_obj.to_dict()), 201
@@ -256,6 +259,7 @@ def api_update_event(event_id):
         end_time_str=data.get('end_time'),
         linked_user_id=data.get('user_id') if not unlink_user else None,
         linked_child_id=data.get('child_id') if not unlink_child else None,
+        destination=data.get('destination'),
         unlink_user=unlink_user,
         unlink_child=unlink_child
     )
@@ -553,11 +557,19 @@ def events_view():
     user_events = event_manager.get_events_for_user(user_id=user_id)
     user_children = child_manager.get_user_children(user_id=user_id) # For the dropdown
 
-    # Enhance event objects with child names if linked
-    # This is a bit inefficient here; ideally, a JOIN in the query or a method in the model would do this.
-    # For now, let's try to add child names if a child_id exists for simplicity in template.
-    # This is not ideal as it leads to N+1 queries if not careful or if ORM doesn't auto-load.
-    # event_manager.get_events_for_user already returns Event objects with child relationship loaded if accessed.
+    # Add travel recommendations if HOME_ADDRESS env var is set
+    origin = os.environ.get('HOME_ADDRESS')
+    if origin:
+        for e in user_events:
+            if e.destination and e.start_time:
+                try:
+                    info = travel_info.get_route_info(origin, e.destination)
+                    mins = info.get('duration_minutes')
+                    if mins is not None:
+                        e.recommended_leave_time = e.start_time - timedelta(minutes=mins)
+                        e.traffic_warning = info.get('traffic_warning')
+                except Exception as ex:
+                    print(f"Travel info error: {ex}")
 
     return render_template('events.html', events=user_events, children=user_children)
 
@@ -573,6 +585,7 @@ def add_event_web():
     start_time_str_html = request.form.get('start_time') # HTML datetime-local
     end_time_str_html = request.form.get('end_time')     # HTML datetime-local
     child_id_str = request.form.get('child_id')
+    destination = request.form.get('destination')
 
     if not title or not start_time_str_html or not end_time_str_html:
         flash('Title, start time, and end time are required for an event.', 'danger')
@@ -603,6 +616,7 @@ def add_event_web():
     new_event = event_manager.create_event(
         title=title,
         description=description,
+        destination=destination,
         start_time_str=start_time_formatted,
         end_time_str=end_time_formatted,
         linked_user_id=user_id, # Auto-link to current user

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 SQLAlchemy
 pytest
+requests

--- a/src/event.py
+++ b/src/event.py
@@ -9,6 +9,7 @@ class Event(Base):
     id = Column(Integer, primary_key=True, index=True)
     title = Column(String, index=True)
     description = Column(String, nullable=True)
+    destination = Column(String, nullable=True)
     start_time = Column(DateTime) # Previous: start_time (str)
     end_time = Column(DateTime)   # Previous: end_time (str)
 
@@ -38,6 +39,7 @@ class Event(Base):
             "id": self.id,
             "title": self.title,
             "description": self.description,
+            "destination": self.destination,
             "start_time": self.start_time.isoformat() if self.start_time else None,
             "end_time": self.end_time.isoformat() if self.end_time else None,
             "user_id": self.user_id,

--- a/src/event_manager.py
+++ b/src/event_manager.py
@@ -22,7 +22,8 @@ def _parse_datetime(datetime_str: str):
         return None
 
 def create_event(title: str, description: str, start_time_str: str, end_time_str: str,
-                 linked_user_id: int = None, linked_child_id: int = None):
+                 linked_user_id: int = None, linked_child_id: int = None,
+                 destination: str = None):
     db = SessionLocal()
     try:
         start_time_dt = _parse_datetime(start_time_str)
@@ -36,6 +37,7 @@ def create_event(title: str, description: str, start_time_str: str, end_time_str
         new_event = Event(
             title=title,
             description=description,
+            destination=destination,
             start_time=start_time_dt,
             end_time=end_time_dt,
             user_id=linked_user_id, # This is the FK field in Event model
@@ -90,6 +92,7 @@ def get_events_for_child(child_id: int):
 def update_event(event_id: int, title: str = None, description: str = None,
                  start_time_str: str = None, end_time_str: str = None,
                  linked_user_id: int = None, linked_child_id: int = None,
+                 destination: str = None,
                  unlink_user: bool = False, unlink_child: bool = False): # Added unlink flags
     db = SessionLocal()
     try:
@@ -104,6 +107,9 @@ def update_event(event_id: int, title: str = None, description: str = None,
             updated = True
         if description is not None:
             event.description = description
+            updated = True
+        if destination is not None:
+            event.destination = destination
             updated = True
         if start_time_str is not None:
             start_time_dt = _parse_datetime(start_time_str)

--- a/src/travel_info.py
+++ b/src/travel_info.py
@@ -1,0 +1,37 @@
+import os
+import requests
+
+GOOGLE_MAPS_ENDPOINT = "https://maps.googleapis.com/maps/api/directions/json"
+
+
+def get_route_info(origin: str, destination: str, api_key: str | None = None) -> dict:
+    """Return travel duration in minutes and a traffic warning."""
+    api_key = api_key or os.environ.get("GOOGLE_MAPS_API_KEY")
+    if not api_key:
+        return {"duration_minutes": None, "traffic_warning": False}
+
+    params = {
+        "origin": origin,
+        "destination": destination,
+        "departure_time": "now",
+        "key": api_key,
+    }
+
+    try:
+        resp = requests.get(GOOGLE_MAPS_ENDPOINT, params=params, timeout=5)
+        data = resp.json()
+        leg = data["routes"][0]["legs"][0]
+        duration = leg.get("duration", {}).get("value")
+        duration_in_traffic = leg.get("duration_in_traffic", {}).get("value", duration)
+        mins = duration // 60 if duration else None
+        mins_traffic = duration_in_traffic // 60 if duration_in_traffic else mins
+        traffic_warning = False
+        if mins and mins_traffic and mins_traffic - mins > 10:
+            traffic_warning = True
+        return {
+            "duration_minutes": mins_traffic,
+            "traffic_warning": traffic_warning,
+        }
+    except Exception as e:
+        print(f"Error fetching route info: {e}")
+        return {"duration_minutes": None, "traffic_warning": False}

--- a/templates/events.html
+++ b/templates/events.html
@@ -11,11 +11,20 @@
                 <li>
                     <strong>{{ event.title }}</strong>
                     <p>{{ event.description if event.description else 'No description.' }}</p>
+                    {% if event.destination %}
+                        <p>Destination: {{ event.destination }}</p>
+                    {% endif %}
                     <small>
                         From: {{ event.start_time.strftime('%Y-%m-%d %H:%M') if event.start_time else 'N/A' }} <br>
                         To: {{ event.end_time.strftime('%Y-%m-%d %H:%M') if event.end_time else 'N/A' }}
                     </small>
                     <br>
+                    {% if event.recommended_leave_time %}
+                        <em>Leave by {{ event.recommended_leave_time.strftime('%Y-%m-%d %H:%M') }}</em><br>
+                    {% endif %}
+                    {% if event.traffic_warning %}
+                        <strong style="color:red;">Heavy traffic reported</strong><br>
+                    {% endif %}
                     <small>
                         {% if event.user_id and event.child_id %}
                             Linked to: User (Self) and Child ID {{ event.child_id }}
@@ -56,6 +65,10 @@
         <div>
             <label for="end_time">End Time:</label>
             <input type="datetime-local" id="end_time" name="end_time" required>
+        </div>
+        <div>
+            <label for="destination">Destination (Optional):</label>
+            <input type="text" id="destination" name="destination">
         </div>
         <div>
             <label for="child_id">Link to Child (Optional):</label>


### PR DESCRIPTION
## Summary
- add travel information helper using Google Directions API
- include `destination` column for events
- enhance event forms with destination field
- display recommended leave times and traffic warnings
- support requests library

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840de07fda4832aa0ecb32b4da89689