### PR TITLE
Add plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,32 @@ pytest
 ```
 
 This will execute the unit tests for the API and manager modules.
+
+## Plugins
+
+The application supports simple plugins located in `src/plugins/`. Each plugin
+is a Python module that defines a `Plugin` class with a `name` attribute and a
+`register(app)` method. Optional cleanup can be provided with an
+`unregister(app)` method.
+
+Place your plugin file in `src/plugins/` and restart the application. Visit
+`/admin/plugins` in the web interface to enable or disable discovered plugins.
+
+### Example Plugin
+
+```python
+# src/plugins/sample.py
+from flask import Blueprint
+
+bp = Blueprint("sample", __name__)
+
+@bp.route("/sample")
+def hello():
+    return "Hello from sample plugin"
+
+class Plugin:
+    name = "Sample"
+
+    def register(self, app):
+        app.register_blueprint(bp)
+```

--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ import os # For secret key
 
 from src import auth, user, shift, child, event # Models
 from src import shift_manager, child_manager, event_manager, shift_pattern_manager # Managers
+# Plugin system
+from src.plugins import PluginManager
 from src.database import init_db, SessionLocal
 # Import residency_period model for init_db
 from src import residency_period
@@ -23,6 +25,7 @@ except Exception as e:
 
 app = Flask(__name__)
 app.secret_key = os.urandom(24) # Generate a random secret key for sessions
+plugin_manager = PluginManager(app)
 
 # Optional: A generic error handler for unhandled exceptions
 @app.errorhandler(Exception)
@@ -485,6 +488,20 @@ def logout():
     session.pop('user_name', None)
     flash('You have been successfully logged out.', 'success')
     return redirect(url_for('index'))
+
+# --- Plugin Management Web Route ---
+@app.route('/admin/plugins', methods=['GET', 'POST'])
+def manage_plugins():
+    if request.method == 'POST':
+        plugin_name = request.form.get('plugin')
+        action = request.form.get('action')
+        if action == 'enable':
+            plugin_manager.enable_plugin(plugin_name)
+        elif action == 'disable':
+            plugin_manager.disable_plugin(plugin_name)
+        return redirect(url_for('manage_plugins'))
+    plugins = plugin_manager.list_plugins()
+    return render_template('plugins.html', plugins=plugins)
 
 # --- Shift Web Routes ---
 

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -1,0 +1,52 @@
+import importlib
+import pkgutil
+from typing import Dict
+
+
+class BasePlugin:
+    """Base class for plugins."""
+    name = "BasePlugin"
+    enabled = False
+
+    def register(self, app):
+        """Register plugin components on the Flask app."""
+        pass
+
+    def unregister(self, app):
+        """Optional cleanup when disabling a plugin."""
+        pass
+
+
+class PluginManager:
+    """Discover and manage plugins."""
+
+    def __init__(self, app, package: str = 'src.plugins'):
+        self.app = app
+        self.package = package
+        self.plugins: Dict[str, BasePlugin] = {}
+        self.discover_plugins()
+
+    def discover_plugins(self):
+        package = importlib.import_module(self.package)
+        for _, module_name, _ in pkgutil.iter_modules(package.__path__):
+            module = importlib.import_module(f"{self.package}.{module_name}")
+            plugin_cls = getattr(module, 'Plugin', None)
+            if plugin_cls is not None:
+                plugin = plugin_cls()
+                self.plugins[plugin.name] = plugin
+
+    def list_plugins(self):
+        return [{'name': name, 'enabled': plugin.enabled} for name, plugin in self.plugins.items()]
+
+    def enable_plugin(self, name: str):
+        plugin = self.plugins.get(name)
+        if plugin and not plugin.enabled:
+            plugin.register(self.app)
+            plugin.enabled = True
+
+    def disable_plugin(self, name: str):
+        plugin = self.plugins.get(name)
+        if plugin and plugin.enabled:
+            if hasattr(plugin, 'unregister'):
+                plugin.unregister(self.app)
+            plugin.enabled = False

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -30,6 +30,7 @@
         <nav>
             <ul>
                 <li><a href="{{ url_for('index') }}">Home</a></li>
+                <li><a href="{{ url_for('manage_plugins') }}">Plugins</a></li>
                 {% if session.get('user_id') %}
                     <li><a href="{{ url_for('logout') }}">Logout</a></li>
                     {# Add other authenticated links here, e.g., Profile, Dashboard #}

--- a/templates/plugins.html
+++ b/templates/plugins.html
@@ -1,0 +1,31 @@
+{% extends "layout.html" %}
+
+{% block title %}Plugins{% endblock %}
+
+{% block content %}
+<h2>Plugin Management</h2>
+<table>
+    <tr><th>Name</th><th>Status</th><th>Action</th></tr>
+    {% for plugin in plugins %}
+    <tr>
+        <td>{{ plugin.name }}</td>
+        <td>{{ 'Enabled' if plugin.enabled else 'Disabled' }}</td>
+        <td>
+            {% if plugin.enabled %}
+            <form method="POST" style="display:inline;">
+                <input type="hidden" name="plugin" value="{{ plugin.name }}">
+                <input type="hidden" name="action" value="disable">
+                <input type="submit" value="Disable">
+            </form>
+            {% else %}
+            <form method="POST" style="display:inline;">
+                <input type="hidden" name="plugin" value="{{ plugin.name }}">
+                <input type="hidden" name="action" value="enable">
+                <input type="submit" value="Enable">
+            </form>
+            {% endif %}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add minimal plugin framework with `PluginManager`
- expose `/admin/plugins` page for managing plugins
- link plugin admin page from layout and document how to create plugins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840de0bf0ec832aab7568dbf2796c34