### PR TITLE
Add institution model and consent endpoints

### DIFF
--- a/src/consent.py
+++ b/src/consent.py
@@ -1,0 +1,29 @@
+from sqlalchemy import Column, Integer, Boolean, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+from src.database import Base
+
+class Consent(Base):
+    __tablename__ = "consents"
+
+    id = Column(Integer, primary_key=True, index=True)
+    child_id = Column(Integer, ForeignKey('children.id'), nullable=False)
+    institution_id = Column(Integer, ForeignKey('institutions.id'), nullable=False)
+    approved = Column(Boolean, default=True)
+
+    child = relationship("Child")
+    institution = relationship("Institution")
+
+    __table_args__ = (UniqueConstraint('child_id', 'institution_id', name='_child_institution_uc'),)
+
+    def to_dict(self, include_child=False, include_institution=False):
+        data = {
+            "id": self.id,
+            "child_id": self.child_id,
+            "institution_id": self.institution_id,
+            "approved": self.approved
+        }
+        if include_child and self.child:
+            data['child'] = {"id": self.child.id, "name": self.child.name}
+        if include_institution and self.institution:
+            data['institution'] = {"id": self.institution.id, "name": self.institution.name}
+        return data

--- a/src/event.py
+++ b/src/event.py
@@ -12,9 +12,10 @@ class Event(Base):
     start_time = Column(DateTime) # Previous: start_time (str)
     end_time = Column(DateTime)   # Previous: end_time (str)
 
-    # Foreign keys to link event to a user and/or a child
+    # Foreign keys to link event to a user, child, or institution
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True) # Previous: linked_user_id (str, uuid)
     child_id = Column(Integer, ForeignKey("children.id"), nullable=True) # Previous: linked_child_id (str, uuid)
+    institution_id = Column(Integer, ForeignKey("institutions.id"), nullable=True)
 
     # Relationships (optional, but good for accessing related objects)
     # If an event can be linked to a User, this defines how to access that User object
@@ -23,6 +24,7 @@ class Event(Base):
 
     # If an event can be linked to a Child, this defines how to access that Child object
     child = relationship("Child") # Similarly, no back_populates if Child model doesn't have a direct list of events.
+    institution = relationship("Institution", back_populates="events")
 
     # Removed __init__ as SQLAlchemy handles it.
     # Previous Event model had: event_id, title, description, start_time, end_time, linked_user_id, linked_child_id
@@ -33,7 +35,7 @@ class Event(Base):
     def __repr__(self):
         return f"<Event(id={self.id}, title='{self.title}')>"
 
-    def to_dict(self, include_user=True, include_child=True):
+    def to_dict(self, include_user=True, include_child=True, include_institution=True):
         data = {
             "id": self.id,
             "title": self.title,
@@ -41,11 +43,14 @@ class Event(Base):
             "start_time": self.start_time.isoformat() if self.start_time else None,
             "end_time": self.end_time.isoformat() if self.end_time else None,
             "user_id": self.user_id,
-            "child_id": self.child_id
+            "child_id": self.child_id,
+            "institution_id": self.institution_id
         }
         # Optionally include simplified representations of linked user/child
         if include_user and self.user: # self.user is the relationship attribute
             data['user'] = {"id": self.user.id, "name": self.user.name}
         if include_child and self.child: # self.child is the relationship attribute
             data['child'] = {"id": self.child.id, "name": self.child.name}
+        if include_institution and self.institution:
+            data['institution'] = {"id": self.institution.id, "name": self.institution.name}
         return data

--- a/src/institution.py
+++ b/src/institution.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+from src.database import Base
+
+class Institution(Base):
+    __tablename__ = "institutions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, index=True)
+    type = Column(String)
+    api_key = Column(String, unique=True, nullable=False)
+
+    events = relationship("Event", back_populates="institution")
+    treatment_plans = relationship("TreatmentPlan", back_populates="institution")
+
+    def to_dict(self):
+        return {"id": self.id, "name": self.name, "type": self.type}

--- a/src/treatment_plan.py
+++ b/src/treatment_plan.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import relationship
+from src.database import Base
+
+class TreatmentPlan(Base):
+    __tablename__ = "treatment_plans"
+
+    id = Column(Integer, primary_key=True, index=True)
+    child_id = Column(Integer, ForeignKey('children.id'), nullable=False)
+    institution_id = Column(Integer, ForeignKey('institutions.id'), nullable=False)
+    description = Column(String)
+    start_date = Column(Date)
+    end_date = Column(Date)
+
+    child = relationship("Child")
+    institution = relationship("Institution", back_populates="treatment_plans")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "child_id": self.child_id,
+            "institution_id": self.institution_id,
+            "description": self.description,
+            "start_date": self.start_date.isoformat() if self.start_date else None,
+            "end_date": self.end_date.isoformat() if self.end_date else None,
+        }

--- a/tests/test_api_institutions.py
+++ b/tests/test_api_institutions.py
@@ -1,0 +1,103 @@
+import unittest
+import os
+import hashlib
+import sys
+from datetime import date
+
+sys_path_updated = False
+if os.path.abspath(os.path.join(os.path.dirname(__file__), '..')) not in sys.path:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    sys_path_updated = True
+
+os.environ["TEST_MODE_ENABLED"] = "1"
+
+from app import app
+from src.database import initialize_database_for_application, create_tables, drop_tables, SessionLocal
+from src.user import User
+from src.child import Child
+from src.institution import Institution
+from src.consent import Consent
+
+class TestAPIInstitutions(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        initialize_database_for_application()
+        app.config['TESTING'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        app.config['SECRET_KEY'] = 'test_secret_key_institutions'
+        from src import user, shift, child, event, shift_pattern, residency_period, institution, consent, treatment_plan
+        create_tables()
+
+    @classmethod
+    def tearDownClass(cls):
+        drop_tables()
+        if "TEST_MODE_ENABLED" in os.environ:
+            del os.environ["TEST_MODE_ENABLED"]
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.db = SessionLocal()
+        self.db.query(Consent).delete()
+        self.db.query(Institution).delete()
+        self.db.query(Child).delete()
+        self.db.query(User).delete()
+        self.db.commit()
+        self.parent = self._create_user("Parent", "parent@example.com")
+        self.child = self._create_child(self.parent.id)
+
+    def tearDown(self):
+        self.db.query(Consent).delete()
+        self.db.query(Institution).delete()
+        self.db.query(Child).delete()
+        self.db.query(User).delete()
+        self.db.commit()
+        self.db.close()
+
+    def _create_user(self, name, email):
+        hashed_password = hashlib.sha256(b"pw").hexdigest()
+        user = User(name=name, email=email, hashed_password=hashed_password)
+        self.db.add(user)
+        self.db.commit()
+        self.db.refresh(user)
+        return user
+
+    def _create_child(self, parent_id):
+        c = Child(name="Child", date_of_birth=date(2020,1,1))
+        parent = self.db.query(User).get(parent_id)
+        c.parents.append(parent)
+        self.db.add(c)
+        self.db.commit()
+        self.db.refresh(c)
+        return c
+
+    def test_institution_event_requires_consent(self):
+        inst_res = self.client.post('/institutions', json={"name": "School"})
+        self.assertEqual(inst_res.status_code, 201)
+        inst = inst_res.get_json()
+        key = inst['api_key']
+        # Attempt event without consent
+        response = self.client.post(f"/institutions/{inst['id']}/events", json={
+            "title": "Class Trip",
+            "start_time": "2024-01-01 09:00",
+            "end_time": "2024-01-01 15:00",
+            "child_id": self.child.id
+        }, headers={"X-API-Key": key})
+        self.assertEqual(response.status_code, 403)
+        # Give consent
+        c_res = self.client.post(f"/children/{self.child.id}/institutions/{inst['id']}/consent")
+        self.assertEqual(c_res.status_code, 201)
+        # Retry event
+        response2 = self.client.post(f"/institutions/{inst['id']}/events", json={
+            "title": "Class Trip",
+            "start_time": "2024-01-01 09:00",
+            "end_time": "2024-01-01 15:00",
+            "child_id": self.child.id
+        }, headers={"X-API-Key": key})
+        self.assertEqual(response2.status_code, 201)
+        data = response2.get_json()
+        self.assertEqual(data['child_id'], self.child.id)
+        self.assertEqual(data['institution_id'], inst['id'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add models for `Institution`, `Consent`, and `TreatmentPlan`
- extend `Event` model to link institutions
- allow event manager to handle institution events
- provide REST endpoints for institutions with API-key auth
- manage parental consent
- add tests for institution event consent flow

## Testing
- `python -m py_compile app.py src/*.py tests/test_api_institutions.py`
- `pytest -q` *(fails: ModuleNotFoundError for flask and sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6840de102f94832abbf1838b993edffc