### PR TITLE
Add pinned deps and test helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: test
+
+test:
+	TEST_MODE_ENABLED=1 python src/database.py >/dev/null 2>&1 || true
+	TEST_MODE_ENABLED=1 pytest

--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ Visit `http://localhost:5000` in your browser.
 
 ## Running Tests
 
-Install the requirements as above and run:
+Install the requirements as above and set the `TEST_MODE_ENABLED` environment
+variable so an in-memory test database is used. Then run the tests:
 
 ```bash
+export TEST_MODE_ENABLED=1
 pytest
 ```
 
-This will execute the unit tests for the API and manager modules.
+You can also run `make test`, which sets up the database and invokes `pytest`
+automatically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Flask
-SQLAlchemy
+Flask==3.0.2
+SQLAlchemy==2.0.25
 pytest


### PR DESCRIPTION
## Summary
- pin Flask and SQLAlchemy versions
- explain how to enable test mode in README
- add `make test` helper

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840de12ef28832ab5d1dbde3eafcd42